### PR TITLE
fix: add missing .catch() on init() chain in GameRunner.start()

### DIFF
--- a/src/runner/GameRunner.js
+++ b/src/runner/GameRunner.js
@@ -119,7 +119,8 @@ export class GameRunner {
                                     resolve(this.getCurrentLevel());
                                 })
                                 .catch(reject);
-                        });
+                        })
+                        .catch(reject);
                 });
             }
         });


### PR DESCRIPTION
If onCreate() or Physics.init() threw during level initialization, the error was silently swallowed and onStart() would never be called with no console output. Added .catch(reject) so errors propagate to the caller.