### PR TITLE
feat: enable physics on-demand for ThirdPersonControl

### DIFF
--- a/src/controls/Controls.js
+++ b/src/controls/Controls.js
@@ -8,6 +8,8 @@ import { EventDispatcher, Vector3 } from "three";
 import { DEPRECATIONS } from "../lib/messages";
 import { AVAILABLE_CONTROLS, CONTROLS } from "./constants";
 import Universe from "../core/universe";
+import Config from "../core/config";
+import Physics from "../physics";
 
 export const THREEJS_CONTROL_EVENTS = {
     CHANGE: "change",
@@ -144,8 +146,27 @@ export class Controls extends EventDispatcher {
         return this.controls[CONTROLS.FPS];
     }
 
-    setThirdPersonControls(options) {
+    async setThirdPersonControls(options) {
         this.disposePreviousControls([CONTROLS.FPS, CONTROLS.FLY, CONTROLS.ORBIT]);
+
+        // Ensure the global physics system is initialised when the control
+        // requests physics.  The builder/preview config may not have enabled
+        // physics explicitly, so we enable it on-demand here.
+        if (options.physicsEnabled && !Config.physics().enabled) {
+            Config.physics().enabled = true;
+            await Physics.init();
+
+            // Entities loaded before physics was enabled had their
+            // enablePhysics() calls silently skipped.  Now that the
+            // worker is ready, add every entity that has pending
+            // physics options to the world.
+            Universe.forEach(element => {
+                if (element._physicsEnabled && !Physics.hasElement(element)) {
+                    Physics.add(element, element.getPhysicsOptions());
+                }
+            });
+        }
+
         this.controls[CONTROLS.TPS] = new ThirdPersonControl(
             Scene.getCamera(),
             Scene.getDOMElement(),

--- a/src/controls/ThirdPersonControl.js
+++ b/src/controls/ThirdPersonControl.js
@@ -1,7 +1,7 @@
 import { EventDispatcher, Vector3, Euler, Quaternion, MathUtils } from "three";
 
 import { debounce } from "../lib/functions";
-import { PHYSICS_ELEMENT_MISSING } from "../lib/messages";
+import { PHYSICS_ELEMENT_MISSING, THIRD_PERSON_CONTROL_TARGET_MISSING } from "../lib/messages";
 
 import Physics, { PHYSICS_CONSTANTS } from "../physics";
 
@@ -81,6 +81,11 @@ export default class ThirdPersonControl extends EventDispatcher {
     }
 
     init() {
+        if (!this.character) {
+            console.error(THIRD_PERSON_CONTROL_TARGET_MISSING);
+            return;
+        }
+
         this._onClick = this.onClick.bind(this);
         this._onMouseMove = this.onMouseMove.bind(this);
         this._onKeyDown = this.onKeyDown.bind(this);
@@ -97,7 +102,7 @@ export default class ThirdPersonControl extends EventDispatcher {
 
         // In non-physics mode, use the character's starting Y as ground level
         // when no explicit value was provided, so it doesn't free-fall on start.
-        if (!this.hasPhysicsEnabled() && this.character) {
+        if (!this.hasPhysicsEnabled()) {
             const startY = this.character.getPosition().y;
             if (this.options.groundLevel === 0.5 && startY > 1) {
                 this.options.groundLevel = startY;
@@ -106,7 +111,7 @@ export default class ThirdPersonControl extends EventDispatcher {
             this.canJump = true;
         }
 
-        if (this.hasPhysicsEnabled() && this.character) {
+        if (this.hasPhysicsEnabled()) {
             this.addCharacterToPhysics();
         }
     }
@@ -135,7 +140,7 @@ export default class ThirdPersonControl extends EventDispatcher {
     hasPhysicsEnabled = () => this.options.physicsEnabled;
 
     getCharacter() {
-        return this.character || this.camera;
+        return this.character;
     }
 
     // --- Pointer Lock ---
@@ -448,7 +453,7 @@ export default class ThirdPersonControl extends EventDispatcher {
     // Called AFTER handlePhysicsUpdate runs on all elements,
     // so we can safely override the quaternion that physics reset.
     physicsUpdate() {
-        if (this.hasPhysicsEnabled() && this.character) {
+        if (this.hasPhysicsEnabled()) {
             // Re-enable jumping when grounded AND space is released
             const grounded = this.character.getPhysicsState("grounded");
             if (grounded && !this.spaceHeld) {
@@ -483,8 +488,6 @@ export default class ThirdPersonControl extends EventDispatcher {
         }
 
         // Always position camera relative to character
-        if (this.character) {
-            this.updateCameraPosition();
-        }
+        this.updateCameraPosition();
     }
 }

--- a/src/entities/Element.js
+++ b/src/entities/Element.js
@@ -403,6 +403,7 @@ export default class Element extends Entity {
 
     enablePhysics(options = {}) {
         this.setPhysicsOptions(options);
+        this._physicsEnabled = true;
 
         if (Config.physics().enabled) {
             Physics.add(this, options);

--- a/src/lib/messages.js
+++ b/src/lib/messages.js
@@ -108,3 +108,5 @@ export const SOUND_HOLDER_MODEL_NOT_FOUND = `${PREFIX} This sound holder model c
 
 export const LABEL_DOMELEMENT_MISSING = `${PREFIX} Could not create Label, domElement is missing. Did you forget to set the this.element ref on your component?`;
 export const NO_VALID_LEVEL_DATA_PROVIDED = `${PREFIX} No valid level data (json or url) provided`;
+
+export const THIRD_PERSON_CONTROL_TARGET_MISSING = `${PREFIX} ThirdPersonControl requires a target element. Please provide a valid target.`;

--- a/src/physics/index.js
+++ b/src/physics/index.js
@@ -6,6 +6,7 @@ import PhysicsWorker from "worker:./worker";
 import { PHYSICS_EVENTS } from "./messages";
 import * as physicsUtils from "./utils";
 import { getHostURL } from "../lib/url";
+import env from "../env";
 import { PHYSICS_ELEMENT_ALREADY_STORED, PHYSICS_ELEMENT_CANT_BE_REMOVED } from "../lib/messages";
 
 import * as PHYSICS_CONSTANTS from "./constants";
@@ -110,10 +111,18 @@ export class Physics extends EventDispatcher {
         if (Config.physics().enabled) {
             this.createWorker();
 
+            // Resolve ammo.js using MAGE_ASSETS_BASE_URL (same as models,
+            // images, and audio) so the path works identically in local
+            // preview and production.
+            const baseUrl = env.MAGE_ASSETS_BASE_URL;
+            const host = baseUrl
+                ? `${getHostURL()}/${baseUrl}`
+                : getHostURL();
+
             this.worker.postMessage({
                 event: PHYSICS_EVENTS.LOAD.AMMO,
                 ...Config.physics(),
-                host: getHostURL(),
+                host,
             });
 
             return new Promise(resolve => {

--- a/src/physics/index.js
+++ b/src/physics/index.js
@@ -115,9 +115,7 @@ export class Physics extends EventDispatcher {
             // images, and audio) so the path works identically in local
             // preview and production.
             const baseUrl = env.MAGE_ASSETS_BASE_URL;
-            const host = baseUrl
-                ? `${getHostURL()}/${baseUrl}`
-                : getHostURL();
+            const host = baseUrl ? `${getHostURL()}/${baseUrl}` : getHostURL();
 
             this.worker.postMessage({
                 event: PHYSICS_EVENTS.LOAD.AMMO,


### PR DESCRIPTION
Remove the silent camera fallback from ThirdPersonControl — a target element is now required, with a clear error if missing.

When physicsEnabled is requested but global physics is off, lazily initialise the physics worker and retroactively add any entities that had enablePhysics() called before the worker existed.  Resolve ammo.js via MAGE_ASSETS_BASE_URL so the path works identically in local preview and production.