### PR TITLE
fix: default physics mass to 0 (static) instead of 1 (dynamic)

### DIFF
--- a/src/physics/__tests__/utils.test.js
+++ b/src/physics/__tests__/utils.test.js
@@ -18,8 +18,8 @@ import { PHYSICS_EVENTS } from "../messages";
 
 describe("physics/utils.js", () => {
     describe("DEFAULT_DESCRIPTION", () => {
-        test("has mass of 1", () => {
-            expect(DEFAULT_DESCRIPTION.mass).toBe(1);
+        test("has mass of 0", () => {
+            expect(DEFAULT_DESCRIPTION.mass).toBe(0);
         });
 
         test("has friction of 1", () => {

--- a/src/physics/utils.js
+++ b/src/physics/utils.js
@@ -8,7 +8,7 @@ import { DEFAULT_QUATERNION, DEFAULT_POSITION } from "./constants";
 import { COLLIDER_TYPES } from "./constants";
 
 export const DEFAULT_DESCRIPTION = {
-    mass: 1,
+    mass: 0,
     friction: 1,
     quaternion: DEFAULT_QUATERNION,
     position: DEFAULT_POSITION,

--- a/src/physics/worker/elements.js
+++ b/src/physics/worker/elements.js
@@ -17,7 +17,7 @@ export const createRigidBody = (shape, options) => {
         uuid,
         position,
         quaternion,
-        mass,
+        mass = 0,
         friction,
         restitution = 0.9,
         damping = { linear: 0.2, angular: 0.2 },


### PR DESCRIPTION
DEFAULT_DESCRIPTION.mass was 1, causing bodies to become dynamic and fall when mass wasn't explicitly provided in options. This only surfaced in production where physics is enabled, not in the editor where physics is always off. Also added mass=0 default in createRigidBody as a safety net.