### PR TITLE
feat: per-level physics config with gravity and simulation step knobs

### DIFF
--- a/src/controls/ThirdPersonControl.js
+++ b/src/controls/ThirdPersonControl.js
@@ -3,6 +3,7 @@ import { EventDispatcher, Vector3, Euler, Quaternion, MathUtils } from "three";
 import { debounce } from "../lib/functions";
 import { PHYSICS_ELEMENT_MISSING, THIRD_PERSON_CONTROL_TARGET_MISSING } from "../lib/messages";
 
+import Config from "../core/config";
 import Physics, { PHYSICS_CONSTANTS } from "../physics";
 
 const { COLLIDER_TYPES } = PHYSICS_CONSTANTS;
@@ -404,8 +405,9 @@ export default class ThirdPersonControl extends EventDispatcher {
             pos.z += moveZ * speed * dt;
         }
 
-        // Gravity
-        this.velocity.y -= 9.8 * dt;
+        // Gravity — read from engine config so it matches the physics world
+        const gravityY = Math.abs(Config.physics()?.gravity?.y ?? 30);
+        this.velocity.y -= gravityY * dt;
         pos.y += this.velocity.y * dt;
 
         // Ground clamp

--- a/src/core/__tests__/config.test.js
+++ b/src/core/__tests__/config.test.js
@@ -1,0 +1,168 @@
+import { Config } from "../config";
+
+describe("Config", () => {
+    let config;
+
+    beforeEach(() => {
+        config = new Config();
+    });
+
+    describe("defaults", () => {
+        test("physics defaults", () => {
+            expect(config.physics()).toEqual({
+                enabled: false,
+                path: "./ammo.js",
+                gravity: { x: 0, y: -30, z: 0 },
+                fixedTimeStep: 1 / 60,
+                maxSubSteps: 3,
+            });
+        });
+
+        test("camera defaults", () => {
+            expect(config.camera()).toEqual({ fov: 75, near: 0.1, far: 10000 });
+        });
+
+        test("ui defaults", () => {
+            expect(config.ui()).toEqual({ enabled: true });
+        });
+    });
+
+    describe("setConfig (flat shape → common)", () => {
+        test("merges flat overrides into common", () => {
+            config.setConfig({ physics: { enabled: true } });
+            expect(config.physics()).toEqual({
+                enabled: true,
+                path: "./ammo.js",
+                gravity: { x: 0, y: -30, z: 0 },
+                fixedTimeStep: 1 / 60,
+                maxSubSteps: 3,
+            });
+        });
+
+        test("multiple setConfig calls merge, not replace", () => {
+            config.setConfig({ physics: { enabled: true } });
+            config.setConfig({ fog: { enabled: true, color: "#000000" } });
+            expect(config.physics().enabled).toBe(true);
+            expect(config.fog().enabled).toBe(true);
+            expect(config.fog().color).toBe("#000000");
+        });
+    });
+
+    describe("setConfig (levels key → per-level)", () => {
+        test("stores per-level overrides", () => {
+            config.setConfig({
+                levels: {
+                    moon: { physics: { gravity: { y: -1.6 } } },
+                },
+            });
+            expect(config.physics("moon")).toEqual({
+                enabled: false,
+                path: "./ammo.js",
+                gravity: { x: 0, y: -1.6, z: 0 },
+                fixedTimeStep: 1 / 60,
+                maxSubSteps: 3,
+            });
+        });
+
+        test("level not present falls back to common", () => {
+            config.setConfig({
+                levels: { moon: { physics: { gravity: { y: -1.6 } } } },
+            });
+            expect(config.physics("earth")).toEqual({
+                enabled: false,
+                path: "./ammo.js",
+                gravity: { x: 0, y: -30, z: 0 },
+                fixedTimeStep: 1 / 60,
+                maxSubSteps: 3,
+            });
+        });
+
+        test("accepts both common and levels in one call", () => {
+            config.setConfig({
+                physics: { enabled: true },
+                levels: { moon: { physics: { gravity: { y: -1.6 } } } },
+            });
+            expect(config.physics()).toEqual({
+                enabled: true,
+                path: "./ammo.js",
+                gravity: { x: 0, y: -30, z: 0 },
+                fixedTimeStep: 1 / 60,
+                maxSubSteps: 3,
+            });
+            expect(config.physics("moon")).toEqual({
+                enabled: true,
+                path: "./ammo.js",
+                gravity: { x: 0, y: -1.6, z: 0 },
+                fixedTimeStep: 1 / 60,
+                maxSubSteps: 3,
+            });
+        });
+    });
+
+    describe("current level", () => {
+        beforeEach(() => {
+            config.setConfig({
+                physics: { enabled: true },
+                levels: {
+                    moon: { physics: { gravity: { y: -1.6 } } },
+                    earth: { physics: { gravity: { y: -9.8 } } },
+                },
+            });
+        });
+
+        test("getters use common when no current level", () => {
+            expect(config.physics().gravity.y).toBe(-30);
+        });
+
+        test("getters use merged common+level after setCurrentLevel", () => {
+            config.setCurrentLevel("moon");
+            expect(config.physics().gravity.y).toBe(-1.6);
+            expect(config.physics().enabled).toBe(true);
+        });
+
+        test("switching current level swaps which override applies", () => {
+            config.setCurrentLevel("moon");
+            expect(config.physics().gravity.y).toBe(-1.6);
+            config.setCurrentLevel("earth");
+            expect(config.physics().gravity.y).toBe(-9.8);
+        });
+
+        test("explicit level arg overrides current level", () => {
+            config.setCurrentLevel("moon");
+            expect(config.physics("earth").gravity.y).toBe(-9.8);
+            expect(config.physics().gravity.y).toBe(-1.6);
+        });
+
+        test("current level pointing at unknown level falls back to common", () => {
+            config.setCurrentLevel("mars");
+            expect(config.physics().gravity.y).toBe(-30);
+        });
+    });
+
+    describe("deep merge semantics", () => {
+        test("nested object overrides only specified keys", () => {
+            config.setConfig({
+                levels: { moon: { physics: { gravity: { x: 1 } } } },
+            });
+            expect(config.physics("moon").gravity).toEqual({ x: 1, y: -30, z: 0 });
+        });
+
+        test("common changes do not leak into stored level overrides", () => {
+            config.setConfig({ levels: { moon: { physics: { gravity: { y: -1.6 } } } } });
+            config.setConfig({ physics: { gravity: { x: 5 } } });
+            expect(config.physics("moon").gravity).toEqual({ x: 5, y: -1.6, z: 0 });
+        });
+
+        test("per-level fixedTimeStep and maxSubSteps override", () => {
+            config.setConfig({
+                levels: {
+                    slowmo: { physics: { fixedTimeStep: 1 / 30, maxSubSteps: 5 } },
+                },
+            });
+            expect(config.physics("slowmo").fixedTimeStep).toBe(1 / 30);
+            expect(config.physics("slowmo").maxSubSteps).toBe(5);
+            expect(config.physics().fixedTimeStep).toBe(1 / 60);
+            expect(config.physics().maxSubSteps).toBe(3);
+        });
+    });
+});

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,12 +1,13 @@
 import { SHADOW_TYPES } from "../lights/constants";
 import { createElementFromSelector } from "../lib/dom";
+import { deepMerge } from "../lib/object";
 import { getWindow } from "./window";
 
 const DEFAULT_HEIGHT = 600;
 const DEFAULT_WIDTH = 800;
 const DEFAULT_RATIO = DEFAULT_WIDTH / DEFAULT_HEIGHT;
 
-const DEFAULT_CONFIG = {
+const DEFAULT_COMMON = {
     tests: [],
 
     scripts: {
@@ -44,6 +45,9 @@ const DEFAULT_CONFIG = {
     physics: {
         enabled: false,
         path: "./ammo.js",
+        gravity: { x: 0, y: -30, z: 0 },
+        fixedTimeStep: 1 / 60,
+        maxSubSteps: 3,
     },
 
     camera: {
@@ -58,29 +62,34 @@ const DEFAULT_CONFIG = {
     },
 };
 
-class Config {
+export class Config {
     constructor() {
-        this.default = DEFAULT_CONFIG;
-        this.isDefault = true;
+        this.config = {
+            common: { ...DEFAULT_COMMON },
+            levels: {},
+        };
+        this.currentLevel = null;
     }
 
     setContainer(container) {
         this._container = container;
     }
 
-    setConfig(config) {
-        if (this.isDefault) {
-            this.isDefault = false;
-            this.config = {
-                ...this.default,
-                ...config,
-            };
-        } else {
-            this.config = {
-                ...this.config,
-                config,
-            };
-        }
+    setConfig(config = {}) {
+        const { levels = {}, ...commonOverrides } = config;
+        this.config.common = deepMerge(this.config.common, commonOverrides);
+        this.config.levels = deepMerge(this.config.levels, levels);
+    }
+
+    setCurrentLevel(level) {
+        this.currentLevel = level;
+    }
+
+    resolve(key, level = this.currentLevel) {
+        const commonValue = this.config.common[key];
+        const levelValue = level ? this.config.levels[level]?.[key] : undefined;
+        if (levelValue === undefined) return commonValue;
+        return deepMerge(commonValue, levelValue);
     }
 
     container() {
@@ -94,16 +103,16 @@ class Config {
         return container;
     }
 
-    tests() {
-        return this.config.tests;
+    tests(level) {
+        return this.resolve("tests", level);
     }
 
-    lights() {
-        return this.config.lights;
+    lights(level) {
+        return this.resolve("lights", level);
     }
 
-    fog() {
-        return this.config.fog;
+    fog(level) {
+        return this.resolve("fog", level);
     }
 
     getContainerSize() {
@@ -137,43 +146,44 @@ class Config {
         };
     }
 
-    screen() {
+    screen(level) {
         const { h, w, ratio } =
             this.getContainerSize() || this.getWindowSize() || this.getScreenDefaults();
 
-        this.config.screen = {
-            ...this.config.screen,
+        this.config.common.screen = {
+            ...this.config.common.screen,
             h,
             w,
             ratio,
             devicePixelRatio: window.devicePixelRatio,
         };
 
-        return this.config.screen;
+        return this.resolve("screen", level);
     }
 
-    postprocessing() {
-        return this.config.postprocessing;
+    postprocessing(level) {
+        return this.resolve("postprocessing", level);
     }
 
-    ui() {
-        return this.config.ui;
+    ui(level) {
+        return this.resolve("ui", level);
     }
 
-    physics() {
-        return this.config.physics;
+    physics(level) {
+        return this.resolve("physics", level);
     }
 
-    camera() {
-        return this.config.camera;
+    camera(level) {
+        return this.resolve("camera", level);
     }
 
-    scripts() {
-        return this.config.scripts;
+    scripts(level) {
+        return this.resolve("scripts", level);
     }
 
     getLevelData(levelPath) {
-        return levelPath ? this.config.levelsData[levelPath] : this.config.levelsData;
+        const levelsData = this.config.common.levelsData;
+        return levelPath ? levelsData[levelPath] : levelsData;
     }
 
     toJSON() {

--- a/src/lib/__tests__/object.test.js
+++ b/src/lib/__tests__/object.test.js
@@ -1,4 +1,4 @@
-import { omit } from "../object";
+import { deepMerge, omit } from "../object";
 
 describe("object.js", () => {
     describe("omit", () => {
@@ -31,6 +31,49 @@ describe("object.js", () => {
         test("handles empty keys array", () => {
             const obj = { a: 1, b: 2 };
             expect(omit([], obj)).toEqual({ a: 1, b: 2 });
+        });
+    });
+
+    describe("deepMerge", () => {
+        test("merges flat objects", () => {
+            expect(deepMerge({ a: 1, b: 2 }, { b: 3, c: 4 })).toEqual({ a: 1, b: 3, c: 4 });
+        });
+
+        test("recursively merges nested objects", () => {
+            const base = { physics: { enabled: false, gravity: { x: 0, y: -30, z: 0 } } };
+            const override = { physics: { gravity: { y: -9.8 } } };
+            expect(deepMerge(base, override)).toEqual({
+                physics: { enabled: false, gravity: { x: 0, y: -9.8, z: 0 } },
+            });
+        });
+
+        test("override replaces arrays rather than concatenating", () => {
+            expect(deepMerge({ list: [1, 2, 3] }, { list: [9] })).toEqual({ list: [9] });
+        });
+
+        test("override replaces primitives", () => {
+            expect(deepMerge({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+        });
+
+        test("override with undefined keeps base value", () => {
+            expect(deepMerge({ a: 1 }, { a: undefined })).toEqual({ a: undefined });
+        });
+
+        test("does not mutate base or override", () => {
+            const base = { a: { b: 1 } };
+            const override = { a: { c: 2 } };
+            deepMerge(base, override);
+            expect(base).toEqual({ a: { b: 1 } });
+            expect(override).toEqual({ a: { c: 2 } });
+        });
+
+        test("returns override when base is not a plain object", () => {
+            expect(deepMerge(null, { a: 1 })).toEqual({ a: 1 });
+            expect(deepMerge(5, { a: 1 })).toEqual({ a: 1 });
+        });
+
+        test("returns base when override is not a plain object", () => {
+            expect(deepMerge({ a: 1 }, null)).toEqual(null);
         });
     });
 });

--- a/src/lib/object.js
+++ b/src/lib/object.js
@@ -8,3 +8,23 @@ export const omit = (keys, map) =>
         const { [key]: _value, ...rest } = acc;
         return rest;
     }, map);
+
+const isPlainObject = value =>
+    value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const deepMerge = (base, override) => {
+    if (!isPlainObject(base) || !isPlainObject(override)) {
+        return override === undefined ? base : override;
+    }
+
+    const result = { ...base };
+    for (const key of Object.keys(override)) {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+        result[key] =
+            isPlainObject(baseValue) && isPlainObject(overrideValue)
+                ? deepMerge(baseValue, overrideValue)
+                : overrideValue;
+    }
+    return result;
+};

--- a/src/lib/object.js
+++ b/src/lib/object.js
@@ -9,8 +9,7 @@ export const omit = (keys, map) =>
         return rest;
     }, map);
 
-const isPlainObject = value =>
-    value !== null && typeof value === "object" && !Array.isArray(value);
+const isPlainObject = value => value !== null && typeof value === "object" && !Array.isArray(value);
 
 export const deepMerge = (base, override) => {
     if (!isPlainObject(base) || !isPlainObject(override)) {

--- a/src/physics/__tests__/init.test.js
+++ b/src/physics/__tests__/init.test.js
@@ -1,0 +1,104 @@
+/**
+ * Integration test for the contract between Config and Physics.init().
+ *
+ * Physics.init() composes the LOAD.AMMO worker message by spreading
+ * Config.physics() into it (src/physics/index.js).  Because every level
+ * switch disposes the physics worker and re-runs init() with the new
+ * current level set on Config, per-level physics overrides flow into
+ * the worker through this single message without any extra plumbing.
+ *
+ * The Physics module itself can't be imported here — it pulls in
+ * `worker:./worker` which is resolved by the bundler, not Jest — so
+ * we reconstruct the payload locally to lock in the contract.
+ */
+
+import { Config } from "../../core/config";
+import { PHYSICS_EVENTS } from "../messages";
+
+const buildLoadAmmoPayload = (config, host = "https://test.host") => ({
+    event: PHYSICS_EVENTS.LOAD.AMMO,
+    ...config.physics(),
+    host,
+});
+
+describe("Physics init payload composition", () => {
+    test("payload carries per-level gravity override when current level is set", () => {
+        const config = new Config();
+        config.setConfig({
+            physics: { enabled: true },
+            levels: {
+                moon: { physics: { gravity: { y: -1.6 } } },
+            },
+        });
+        config.setCurrentLevel("moon");
+
+        const payload = buildLoadAmmoPayload(config);
+
+        expect(payload.event).toBe(PHYSICS_EVENTS.LOAD.AMMO);
+        expect(payload.enabled).toBe(true);
+        expect(payload.gravity).toEqual({ x: 0, y: -1.6, z: 0 });
+    });
+
+    test("payload carries per-level fixedTimeStep and maxSubSteps overrides", () => {
+        const config = new Config();
+        config.setConfig({
+            physics: { enabled: true },
+            levels: {
+                slowmo: { physics: { fixedTimeStep: 1 / 120, maxSubSteps: 5 } },
+            },
+        });
+        config.setCurrentLevel("slowmo");
+
+        const payload = buildLoadAmmoPayload(config);
+
+        expect(payload.fixedTimeStep).toBe(1 / 120);
+        expect(payload.maxSubSteps).toBe(5);
+    });
+
+    test("payload falls back to common physics when no current level is set", () => {
+        const config = new Config();
+        config.setConfig({
+            physics: { enabled: true },
+            levels: {
+                moon: { physics: { gravity: { y: -1.6 } } },
+            },
+        });
+
+        const payload = buildLoadAmmoPayload(config);
+
+        expect(payload.gravity).toEqual({ x: 0, y: -30, z: 0 });
+        expect(payload.fixedTimeStep).toBe(1 / 60);
+        expect(payload.maxSubSteps).toBe(3);
+    });
+
+    test("switching current level yields different payloads", () => {
+        const config = new Config();
+        config.setConfig({
+            physics: { enabled: true },
+            levels: {
+                moon: { physics: { gravity: { y: -1.6 } } },
+                earth: { physics: { gravity: { y: -9.8 } } },
+            },
+        });
+
+        config.setCurrentLevel("moon");
+        const moonPayload = buildLoadAmmoPayload(config);
+
+        config.setCurrentLevel("earth");
+        const earthPayload = buildLoadAmmoPayload(config);
+
+        expect(moonPayload.gravity.y).toBe(-1.6);
+        expect(earthPayload.gravity.y).toBe(-9.8);
+    });
+
+    test("host field is preserved alongside the spread Config.physics()", () => {
+        const config = new Config();
+        config.setConfig({ physics: { enabled: true } });
+
+        const payload = buildLoadAmmoPayload(config, "https://cdn.example/assets");
+
+        expect(payload.host).toBe("https://cdn.example/assets");
+        expect(payload.enabled).toBe(true);
+        expect(payload.path).toBe("./ammo.js");
+    });
+});

--- a/src/physics/constants.js
+++ b/src/physics/constants.js
@@ -46,7 +46,7 @@ export const DEFAULT_ANGULAR_VELOCITY = { x: 0, y: 0, z: 0 };
 export const DEFAULT_IMPULSE = { x: 0, y: 0, z: 0 };
 
 export const DISABLE_DEACTIVATION = 4;
-export const GRAVITY = { x: 0, y: -9.8, z: 0 };
+export const GRAVITY = { x: 0, y: -30, z: 0 };
 
 export const FRONT_LEFT = 0;
 export const FRONT_RIGHT = 1;

--- a/src/physics/worker/vehicles.js
+++ b/src/physics/worker/vehicles.js
@@ -198,6 +198,8 @@ export const handleVehicleUpdate = (
         maxBreakingForce = DEFAULT_MAX_BREAKING_FORCE,
     } = options;
 
+    const speed = vehicle.getCurrentSpeedKmHour();
+
     if (state.acceleration) {
         if (speed < -1) breakingForce = maxBreakingForce;
         else engineForce = maxEngineForce;
@@ -252,7 +254,6 @@ export const handleVehicleUpdate = (
     q = tm.getRotation();
 
     const direction = vehicle.getForwardVector();
-    const speed = vehicle.getCurrentSpeedKmHour();
 
     const extraData = {
         direction: {

--- a/src/physics/worker/world.js
+++ b/src/physics/worker/world.js
@@ -51,7 +51,10 @@ export class World {
     }
 
     init = options => {
-        const { gravity = GRAVITY } = options;
+        const { gravity = GRAVITY, fixedTimeStep = 1 / 60, maxSubSteps = 3 } = options;
+
+        this.fixedTimeStep = fixedTimeStep;
+        this.maxSubSteps = maxSubSteps;
 
         this.collisionConfiguration = new Ammo.btDefaultCollisionConfiguration();
         this.dispatcher = new Ammo.btCollisionDispatcher(this.collisionConfiguration);
@@ -110,7 +113,7 @@ export class World {
     };
 
     stepSimulation = dt => {
-        this.dynamicsWorld.stepSimulation(dt);
+        this.dynamicsWorld.stepSimulation(dt, this.maxSubSteps, this.fixedTimeStep);
     };
 
     simulate = () => {

--- a/src/router/Router.js
+++ b/src/router/Router.js
@@ -47,6 +47,7 @@ class Router {
         this.currentLevel = hash;
 
         Assets.setCurrentLevel(this.currentLevel);
+        Config.setCurrentLevel(this.currentLevel);
     };
 
     getCurrentLevel = () => this.currentLevel;

--- a/src/scripts/builtin/SmoothCarFollow.js
+++ b/src/scripts/builtin/SmoothCarFollow.js
@@ -48,7 +48,8 @@ export default class SmoothCarFollow extends BaseScript {
         const direction = this.target.getPhysicsState("direction");
         if (direction) {
             const { x, y, z } = direction;
-            const cameraPosition = this.camera.getPosition();
+            const { x: cx, y: cy, z: cz } = this.camera.getPosition();
+            const cameraPosition = new Vector3(cx, cy, cz);
             const targetPosition = this.target.getPosition();
             const vector = new Vector3(x, y, z).negate().normalize().multiplyScalar(this.distance);
 
@@ -56,7 +57,7 @@ export default class SmoothCarFollow extends BaseScript {
             const desiredPosition = targetPosition.add(vector);
             const lerpFactor = this.lerpFactor || 1 - Math.pow(0.1, dt);
 
-            cameraPosition.lerpVectors(cameraPosition, desiredPosition, lerpFactor);
+            cameraPosition.lerp(desiredPosition, lerpFactor);
 
             this.camera.setPosition(cameraPosition);
 


### PR DESCRIPTION
Reshape Config storage to { common, levels } so any config block (today just physics) can be overridden per level, mirroring how Assets already handles common vs per-level state. Router pushes the current level into Config alongside Assets, so getters resolve common merged with the current level's overrides. Because each level switch already disposes and re-inits the physics worker, per-level physics flows through the existing LOAD.AMMO message without extra plumbing.

Physics gains fixedTimeStep (1/60) and maxSubSteps (3) alongside gravity (default bumped to -30 for game-feel parity with the third-person controller, which now reads gravity from Config). stepSimulation now uses Ammo's full signature instead of relying on Bullet defaults that silently dropped time on long frames.

Drive-by: setConfig was shallow with a buggy else-branch that lost nested defaults on partial overrides; it now deep-merges, so calls like setConfig({ physics: { enabled: true } }) preserve path/gravity instead of clobbering them.