### PR TITLE
feat(textures): configurable texture offset + setTextureOptions

### DIFF
--- a/src/entities/Element.js
+++ b/src/entities/Element.js
@@ -924,9 +924,15 @@ export default class Element extends Entity {
         }
 
         if (textureId) {
-            const { repeat = { x: 1, y: 1 }, wrap = RepeatWrapping, assetPath } = options;
+            const {
+                repeat = { x: 1, y: 1 },
+                offset = { x: 0, y: 0 },
+                wrap = RepeatWrapping,
+                assetPath,
+            } = options;
             const textureOptions = {
                 repeat,
+                offset,
                 wrap,
             };
 
@@ -943,6 +949,7 @@ export default class Element extends Entity {
                 texture.wrapS = textureOptions.wrap;
                 texture.wrapT = textureOptions.wrap;
                 texture.repeat.set(textureOptions.repeat.x, textureOptions.repeat.y);
+                texture.offset.set(textureOptions.offset.x, textureOptions.offset.y);
 
                 // Set sRGB encoding for color textures (map, emissiveMap, specularMap)
                 // This is required for textures to display with correct colors
@@ -960,6 +967,19 @@ export default class Element extends Entity {
 
             applyMaterialChange(this.getBody(), applyTextureTo);
         }
+    }
+
+    setTextureOptions(textureType = TEXTURES.MAP, options = {}) {
+        const existing = this.textures.get(textureType);
+
+        if (!existing) {
+            return;
+        }
+
+        const { id, assetPath, options: currentOptions = {} } = existing;
+        const mergedOptions = { ...currentOptions, ...options };
+
+        this.setTexture(id, textureType, { ...mergedOptions, assetPath });
     }
 
     getTexture(textureType = TEXTURES.MAP) {


### PR DESCRIPTION
## What

Adds support for a texture's **offset** and a way to update an assigned texture's tiling options without reloading it.

- `Element.setTexture` now reads `offset` from options, applies it (`texture.offset.set(...)`), and records it alongside `repeat`/`wrap` — so it serializes into `EntityConfiguration` and round-trips through save/reload and game builds, exactly like `repeat` already did.
- New `Element.setTextureOptions(type, options)` merges new options (e.g. `{ repeat }` or `{ offset }`) into the texture's recorded options and re-applies them to the material — no texture reload.

## Why

`repeat` was already applied/persisted but `offset` was silently ignored (never recorded, never applied). The editor needs a lightweight way to tweak repeat/offset on an already-assigned texture; `setTextureOptions` provides that.

## Testing

- `npm test` → 505/505 pass (29 suites).
- `npm run build` → `dist/mage.js` builds clean.
- Verified end-to-end against the editor PR below (live repeat/offset edits apply in-viewport and persist on reload).

## Companion PR

Editor wiring: MageStudio/mage-studio#297

🤖 Generated with [Claude Code](https://claude.com/claude-code)