### PR TITLE
feat(textures): per-axis texture wrapping (wrapS/wrapT)

### DIFF
--- a/src/entities/Element.js
+++ b/src/entities/Element.js
@@ -930,10 +930,15 @@ export default class Element extends Entity {
                 wrap = RepeatWrapping,
                 assetPath,
             } = options;
+            // Per-axis wrapping. Fall back to the legacy single `wrap` so textures
+            // recorded before per-axis support still resolve correctly.
+            const wrapS = options.wrapS !== undefined ? options.wrapS : wrap;
+            const wrapT = options.wrapT !== undefined ? options.wrapT : wrap;
             const textureOptions = {
                 repeat,
                 offset,
-                wrap,
+                wrapS,
+                wrapT,
             };
 
             this.recordTexture(textureId, textureType, textureOptions, assetPath);
@@ -946,10 +951,13 @@ export default class Element extends Entity {
                     return;
                 }
 
-                texture.wrapS = textureOptions.wrap;
-                texture.wrapT = textureOptions.wrap;
+                texture.wrapS = textureOptions.wrapS;
+                texture.wrapT = textureOptions.wrapT;
                 texture.repeat.set(textureOptions.repeat.x, textureOptions.repeat.y);
                 texture.offset.set(textureOptions.offset.x, textureOptions.offset.y);
+                // Wrapping is a sampler-level setting, so the texture must be
+                // re-uploaded for a wrap change to take effect.
+                texture.needsUpdate = true;
 
                 // Set sRGB encoding for color textures (map, emissiveMap, specularMap)
                 // This is required for textures to display with correct colors


### PR DESCRIPTION
## What

Adds independent per-axis texture wrapping in `Element.setTexture`:

- Reads `wrapS` / `wrapT` from options and applies them separately (`texture.wrapS` / `texture.wrapT`) instead of collapsing to a single `wrap`.
- Records both axes so they serialize and round-trip through save/reload and game builds.
- Sets `texture.needsUpdate = true` — wrapping is a sampler-level setting, so a change must re-upload the texture.
- Falls back to the legacy single `wrap` when per-axis values are absent, so textures recorded before this still resolve correctly.

Combined with the existing `setTextureOptions` (from #253), callers can update either axis on an already-assigned texture without reloading it.

## Why

Follow-up to #253 (offset + `setTextureOptions`, released in 3.27.2). The editor's redesigned **Wrapping** control lets users set horizontal (S) and vertical (T) wrap modes independently — or link them — which needs the engine to honor per-axis values rather than forcing both to one `wrap`.

## Testing

- `npm test` → 505/505 pass (29 suites).
- Verified live in the editor (engine linked locally) before this PR — linked/independent wrapping applies in-viewport and persists on reload.

## Release / companion

Needs a release (e.g. **3.27.3**) so the editor can consume it. The editor wrapping UI is held until then; it will pin the new version rather than 3.27.2 (which has repeat/offset but not per-axis wrapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)