### PR TITLE
fix(physics): kinematic collider support for movable platforms

### DIFF
--- a/src/physics/constants.js
+++ b/src/physics/constants.js
@@ -46,6 +46,11 @@ export const DEFAULT_ANGULAR_VELOCITY = { x: 0, y: 0, z: 0 };
 export const DEFAULT_IMPULSE = { x: 0, y: 0, z: 0 };
 
 export const DISABLE_DEACTIVATION = 4;
+
+// Bullet btCollisionObject::CollisionFlags
+export const CF_STATIC_OBJECT = 1;
+export const CF_KINEMATIC_OBJECT = 2;
+
 export const GRAVITY = { x: 0, y: -30, z: 0 };
 
 export const FRONT_LEFT = 0;

--- a/src/physics/worker/__tests__/elements.test.js
+++ b/src/physics/worker/__tests__/elements.test.js
@@ -1,0 +1,147 @@
+import { CF_STATIC_OBJECT, CF_KINEMATIC_OBJECT, DISABLE_DEACTIVATION } from "../../constants";
+
+jest.mock("../world", () => ({
+    __esModule: true,
+    default: { addRigidBody: jest.fn(), addElement: jest.fn(), getElement: jest.fn() },
+}));
+jest.mock("../lib/dispatcher", () => ({ __esModule: true, default: { sendBodyUpdate: jest.fn() } }));
+jest.mock("../lib/math", () => ({ applyMatrix4ToVector3: jest.fn() }));
+
+import world from "../world";
+import { makeKinematic, createRigidBody, addBox, addSphere, setQuaternion } from "../elements";
+
+// Minimal fake body that tracks collision flags and activation state.
+const makeFakeBody = (initialFlags = CF_STATIC_OBJECT) => {
+    let flags = initialFlags;
+    return {
+        flags: () => flags,
+        getCollisionFlags: () => flags,
+        setCollisionFlags: jest.fn(f => {
+            flags = f;
+        }),
+        setActivationState: jest.fn(),
+        activate: jest.fn(),
+        setFriction: jest.fn(),
+        setRestitution: jest.fn(),
+        setDamping: jest.fn(),
+        setCcdMotionThreshold: jest.fn(),
+        setCcdSweptSphereRadius: jest.fn(),
+        getWorldTransform: jest.fn(),
+        setWorldTransform: jest.fn(),
+        getMotionState: jest.fn(() => ({ setWorldTransform: jest.fn() })),
+        isStaticObject: () => (flags & CF_STATIC_OBJECT) !== 0,
+    };
+};
+
+// Stub the Ammo global the worker relies on. `initialFlags` lets a test create
+// a dynamic body (flags 0) vs the default static one.
+const installAmmo = (initialFlags = CF_STATIC_OBJECT) => {
+    const body = makeFakeBody(initialFlags);
+    const shape = { calculateLocalInertia: jest.fn() };
+    global.Ammo = {
+        btTransform: function () {
+            return { setIdentity: jest.fn(), setOrigin: jest.fn(), setRotation: jest.fn() };
+        },
+        btVector3: function () {},
+        btQuaternion: function () {},
+        btDefaultMotionState: function () {},
+        btBoxShape: function () {
+            return shape;
+        },
+        btSphereShape: function () {
+            return shape;
+        },
+        btRigidBodyConstructionInfo: function () {},
+        btRigidBody: function () {
+            return body;
+        },
+    };
+    return body;
+};
+
+afterEach(() => {
+    delete global.Ammo;
+    jest.clearAllMocks();
+});
+
+describe("makeKinematic", () => {
+    it("clears the static flag, sets the kinematic flag, and keeps the body awake", () => {
+        const body = makeFakeBody(CF_STATIC_OBJECT);
+
+        makeKinematic(body);
+
+        expect(body.flags() & CF_STATIC_OBJECT).toBe(0);
+        expect(body.flags() & CF_KINEMATIC_OBJECT).toBe(CF_KINEMATIC_OBJECT);
+        expect(body.setActivationState).toHaveBeenCalledWith(DISABLE_DEACTIVATION);
+        expect(body.activate).toHaveBeenCalledWith(true);
+    });
+});
+
+describe("createRigidBody", () => {
+    const options = {
+        uuid: "x",
+        position: { x: 0, y: 0, z: 0 },
+        quaternion: { x: 0, y: 0, z: 0, w: 1 },
+    };
+
+    it("makes a mass-0 body kinematic when the kinematic flag is set", () => {
+        const body = installAmmo();
+
+        createRigidBody(new Ammo.btBoxShape(), { ...options, mass: 0, kinematic: true });
+
+        expect(body.flags() & CF_KINEMATIC_OBJECT).toBe(CF_KINEMATIC_OBJECT);
+        expect(world.addRigidBody).toHaveBeenCalledWith(body);
+    });
+
+    it("leaves a mass-0 body static when kinematic is not set", () => {
+        const body = installAmmo();
+
+        createRigidBody(new Ammo.btBoxShape(), { ...options, mass: 0 });
+
+        expect(body.setCollisionFlags).not.toHaveBeenCalled();
+    });
+});
+
+describe("continuous collision detection", () => {
+    const base = {
+        position: { x: 0, y: 0, z: 0 },
+        quaternion: { x: 0, y: 0, z: 0, w: 1 },
+    };
+
+    it("enables CCD on a dynamic sphere, sized from its radius", () => {
+        const body = installAmmo(0); // dynamic
+        addSphere({ uuid: "s", radius: 2, mass: 10, ...base });
+
+        expect(body.setCcdMotionThreshold).toHaveBeenCalledWith(2 * 0.5);
+        expect(body.setCcdSweptSphereRadius).toHaveBeenCalledWith(2 * 0.8);
+    });
+
+    it("does not enable CCD on a mass-0 (kinematic/static) body", () => {
+        const body = installAmmo();
+        addSphere({ uuid: "s", radius: 2, mass: 0, kinematic: true, ...base });
+
+        expect(body.setCcdMotionThreshold).not.toHaveBeenCalled();
+    });
+});
+
+describe("auto-promotion on script-driven rotation", () => {
+    it("promotes a static body to kinematic the first time setQuaternion runs", () => {
+        installAmmo();
+        const body = makeFakeBody(CF_STATIC_OBJECT);
+        world.getElement.mockReturnValue({ body });
+
+        setQuaternion({ uuid: "x", quaternion: { x: 0, y: 0, z: 0, w: 1 } });
+
+        expect(body.flags() & CF_KINEMATIC_OBJECT).toBe(CF_KINEMATIC_OBJECT);
+    });
+
+    it("does not touch a dynamic body's collision flags", () => {
+        installAmmo();
+        const body = makeFakeBody(0); // not static => dynamic
+        world.getElement.mockReturnValue({ body });
+
+        setQuaternion({ uuid: "x", quaternion: { x: 0, y: 0, z: 0, w: 1 } });
+
+        expect(body.setCollisionFlags).not.toHaveBeenCalled();
+    });
+});

--- a/src/physics/worker/__tests__/elements.test.js
+++ b/src/physics/worker/__tests__/elements.test.js
@@ -4,11 +4,14 @@ jest.mock("../world", () => ({
     __esModule: true,
     default: { addRigidBody: jest.fn(), addElement: jest.fn(), getElement: jest.fn() },
 }));
-jest.mock("../lib/dispatcher", () => ({ __esModule: true, default: { sendBodyUpdate: jest.fn() } }));
+jest.mock("../lib/dispatcher", () => ({
+    __esModule: true,
+    default: { sendBodyUpdate: jest.fn() },
+}));
 jest.mock("../lib/math", () => ({ applyMatrix4ToVector3: jest.fn() }));
 
 import world from "../world";
-import { makeKinematic, createRigidBody, addBox, addSphere, setQuaternion } from "../elements";
+import { makeKinematic, createRigidBody, addSphere, setQuaternion } from "../elements";
 
 // Minimal fake body that tracks collision flags and activation state.
 const makeFakeBody = (initialFlags = CF_STATIC_OBJECT) => {

--- a/src/physics/worker/elements.js
+++ b/src/physics/worker/elements.js
@@ -8,9 +8,33 @@ import {
     TYPES,
     DEFAULT_SCALE,
     DISABLE_DEACTIVATION,
+    CF_STATIC_OBJECT,
+    CF_KINEMATIC_OBJECT,
     DEFAULT_LINEAR_VELOCITY,
     DEFAULT_IMPULSE,
 } from "../constants";
+
+// Turn a body into a kinematic one: it stays mass-0 (infinite mass to the
+// solver) but is driven by its motionState transform rather than frozen like a
+// static body. Bullet derives its linear/angular velocity from the per-step
+// motionState delta and applies that to contacting dynamic bodies, so objects
+// resting on it are carried along instead of falling through.
+export const makeKinematic = body => {
+    const flags = (body.getCollisionFlags() & ~CF_STATIC_OBJECT) | CF_KINEMATIC_OBJECT;
+    body.setCollisionFlags(flags);
+    body.setActivationState(DISABLE_DEACTIVATION);
+    body.activate(true);
+};
+
+// Auto-promote a static body the first time it is moved/rotated by a script.
+// A static body teleported via setWorldTransform reports zero velocity to the
+// solver, so resting dynamic bodies lose their support contact (and can tunnel
+// through a thin collider). Promoting to kinematic fixes both.
+const ensureKinematic = body => {
+    if (body.isStaticObject()) {
+        makeKinematic(body);
+    }
+};
 
 export const createRigidBody = (shape, options) => {
     const {
@@ -21,6 +45,8 @@ export const createRigidBody = (shape, options) => {
         friction,
         restitution = 0.9,
         damping = { linear: 0.2, angular: 0.2 },
+        kinematic = false,
+        ccdRadius = 0,
     } = options;
 
     const transform = new Ammo.btTransform();
@@ -42,10 +68,27 @@ export const createRigidBody = (shape, options) => {
         body.setRestitution(restitution);
         body.setDamping(damping.linear, damping.angular);
         body.setActivationState(DISABLE_DEACTIVATION);
+        // Continuous collision detection so a fast-moving dynamic body can't
+        // tunnel through a thin collider — e.g. a sphere ejected by a rotating
+        // kinematic platform. Mirrors the player capsule's CCD setup.
+        if (ccdRadius > 0) {
+            body.setCcdMotionThreshold(ccdRadius * 0.5);
+            body.setCcdSweptSphereRadius(ccdRadius * 0.8);
+        }
+    } else if (kinematic) {
+        // mass-0 body explicitly flagged as a movable (kinematic) collider.
+        if (friction != null) body.setFriction(friction);
+        makeKinematic(body);
     }
 
     // storing uuid for future reference
     body.uuid = uuid;
+
+    // Authoritative position for kinematic bodies. Bullet extrapolates a
+    // kinematic body's transform from its derived velocity; if we read that
+    // back (getWorldTransform) when only changing rotation, the position drifts
+    // and runs away. We instead pin the origin to this stored value.
+    body.kinematicPosition = { x: position.x, y: position.y, z: position.z };
 
     world.addRigidBody(body);
 
@@ -139,21 +182,48 @@ export const addModel = options => {
 };
 
 export const addBox = data => {
-    const { uuid, width, length, height, position, quaternion, mass = 0, friction = 2 } = data;
+    const {
+        uuid,
+        width,
+        length,
+        height,
+        position,
+        quaternion,
+        mass = 0,
+        friction = 2,
+        kinematic = false,
+    } = data;
 
     const geometry = new Ammo.btBoxShape(
         new Ammo.btVector3(width * 0.5, height * 0.5, length * 0.5),
     );
-    const body = createRigidBody(geometry, { uuid, position, quaternion, mass, friction });
+    const body = createRigidBody(geometry, {
+        uuid,
+        position,
+        quaternion,
+        mass,
+        friction,
+        kinematic,
+        // size CCD from the thinnest half-extent
+        ccdRadius: Math.min(width, height, length) * 0.5,
+    });
 
     world.addElement({ uuid, body, type: TYPES.BOX, state: DEFAULT_RIGIDBODY_STATE });
 };
 
 export const addSphere = data => {
-    const { uuid, radius, position, quaternion, mass = 0, friction = 2 } = data;
+    const { uuid, radius, position, quaternion, mass = 0, friction = 2, kinematic = false } = data;
 
     const geometry = new Ammo.btSphereShape(radius);
-    const body = createRigidBody(geometry, { uuid, position, quaternion, mass, friction });
+    const body = createRigidBody(geometry, {
+        uuid,
+        position,
+        quaternion,
+        mass,
+        friction,
+        kinematic,
+        ccdRadius: radius,
+    });
 
     world.addElement({ uuid, body, type: TYPES.SPHERE, state: DEFAULT_RIGIDBODY_STATE });
 };
@@ -173,6 +243,13 @@ export const setLinearVelocity = data => {
 export const setPosition = data => {
     const { uuid, position } = data;
     const { body } = world.getElement(uuid);
+
+    // A script is moving this collider — promote it from static to kinematic so
+    // it carries resting bodies and doesn't let them tunnel through.
+    ensureKinematic(body);
+
+    // This is the new authoritative position for the kinematic body.
+    body.kinematicPosition = { x: position.x, y: position.y, z: position.z };
 
     const transform = new Ammo.btTransform();
 
@@ -234,8 +311,24 @@ export const setQuaternion = data => {
     const { uuid, quaternion } = data;
     const { body } = world.getElement(uuid);
 
+    // A script is rotating this collider — promote it from static to kinematic
+    // so it carries resting bodies and doesn't let them tunnel through.
+    ensureKinematic(body);
+
     const transform = new Ammo.btTransform();
     body.getWorldTransform(transform);
+
+    // Pin the origin to the authoritative kinematic position rather than
+    // preserving whatever Bullet extrapolated into the world transform. A
+    // kinematic body driven only by rotation must not accumulate positional
+    // drift — reading getWorldTransform back here is what let the platform slide
+    // off and blow up. Fall back to the current origin if we have no stored
+    // position (e.g. a dynamic body being oriented explicitly).
+    const kp = body.kinematicPosition;
+    if (kp && (body.getCollisionFlags() & CF_KINEMATIC_OBJECT) !== 0) {
+        transform.setOrigin(new Ammo.btVector3(kp.x, kp.y, kp.z));
+    }
+
     transform.setRotation(
         new Ammo.btQuaternion(quaternion.x, quaternion.y, quaternion.z, quaternion.w),
     );

--- a/src/physics/worker/world.js
+++ b/src/physics/worker/world.js
@@ -68,6 +68,16 @@ export class World {
         );
         this.dynamicsWorld.setGravity(new Ammo.btVector3(gravity.x, gravity.y, gravity.z));
 
+        // Harden the solver against deep-penetration blow-ups: split impulse
+        // separates positional correction from velocity so recovering from a
+        // deep overlap (e.g. a thin kinematic platform rotating into a large
+        // resting sphere under strong gravity) doesn't inject huge velocities.
+        // More iterations converge stiff contacts under high gravity.
+        const solverInfo = this.dynamicsWorld.getSolverInfo();
+        solverInfo.set_m_splitImpulse(true);
+        solverInfo.set_m_splitImpulsePenetrationThreshold(-0.02);
+        solverInfo.set_m_numIterations(20);
+
         // this is needed for ghostObject collisions
         this.dynamicsWorld
             .getBroadphase()


### PR DESCRIPTION
## Problem
Rotating (or moving) a physics collider with **mass 0** made resting objects fall through it. A mass-0 body is a Bullet **static** body — teleporting its transform each frame reports zero velocity to the solver, so a resting sphere loses support and tunnels through.

## Changes
- **Kinematic bodies**: `makeKinematic` + an explicit `kinematic` flag threaded through `createRigidBody` / `addBox` / `addSphere`. A kinematic body stays mass-0 but is driven by its motionState, so Bullet derives its velocity and carries contacting dynamic bodies.
- **Auto-promotion**: a static body is promoted to kinematic the first time a script moves/rotates it, so existing visual-script graphs work without re-authoring.
- **CCD on dynamic bodies** (sized from the collider) to stop fast bodies tunnelling through thin colliders.
- **Positional-drift fix**: pin a kinematic body's origin to an authoritative `kinematicPosition`. Reading Bullet's *extrapolated* world transform back on a rotation-only update let the body's origin drift and run away — the platform slid off and exploded under non-default gravity. This was the root cause of the gravity-dependent blow-up.
- **Solver hardening**: split impulse + more iterations to resist deep-penetration velocity spikes.

## Tests
Adds unit tests for the kinematic flag arithmetic, CCD wiring, and auto-promotion. Full physics suite green (71 tests).

## Verification
Verified in-editor via preview across multiple gravity settings (default 30, 40, 60): the platform rotates in place, carries the resting sphere, and no longer explodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)