### PR TITLE
fix(physics): compound colliders for rigidly-attached children

### DIFF
--- a/scripts/verify-compound-colliders.js
+++ b/scripts/verify-compound-colliders.js
@@ -168,6 +168,21 @@ ammoFactory().then(A => {
         `sphere.x=${pos.x.toFixed(2)} (expect >3.5), wallCollisions=${wallCollisions()}`,
     );
 
+    // ── Scenario 3: rebuild-on-reparent — worker tears down the compound and
+    //    re-adds the floor alone (what Physics.rebuildAfterReparent emits when the
+    //    wall leaves its parent). The wall collider must physically disappear. ───
+    resetWorld();
+    buildFloor({ withWall: true });
+    world.disposeBody({ uuid: "floor" }); // dispose the floor+wall compound body
+    buildFloor({ withWall: false }); // rebuild the floor alone (wall reparented out)
+    addRollingSphere({ x: 0, y: 1.1, z: 0 }, { x: 12, y: 0, z: 0 });
+    pos = run();
+    check(
+        "reparent-out rebuild removes the wall collider",
+        pos.x > 3.5 && wallCollisions() === 0,
+        `sphere.x=${pos.x.toFixed(2)} (expect >3.5), wallCollisions=${wallCollisions()}`,
+    );
+
     const failed = results.filter(r => !r.pass);
     console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
     process.exit(failed.length ? 1 : 0);

--- a/scripts/verify-compound-colliders.js
+++ b/scripts/verify-compound-colliders.js
@@ -1,0 +1,174 @@
+/* global require, __dirname, process */
+//
+// Real-physics integration harness for compound child colliders.
+//
+// The jest suite mocks Ammo, so it can prove the message/childMap *logic* but not
+// actual collision *response*. This harness loads the real vendored Ammo build
+// (dist/ammo.js) and drives the actual worker code (addCompound, stepSimulation,
+// calculateCollisions) to prove the fix end-to-end:
+//
+//   1. A sphere moving toward a wall that is a *child* of a compound floor is
+//      stopped by the wall (before the fix the child had no collider).
+//   2. Rotating the compound root carries the wall collider with it — a sphere
+//      fired along the rotated axis is still stopped.
+//   3. Control: with the wall removed, the sphere passes straight through.
+//
+// Run with:  node scripts/verify-compound-colliders.js
+// (Ammo is required natively *before* the script enables @babel/register, so
+//  babel's strict-mode transform never touches the emscripten UMD. Do NOT run
+//  with `node -r @babel/register` — that would transform Ammo and break it.)
+
+const path = require("path");
+
+// Globals the worker modules expect (they run in a WebWorker at runtime).
+global.self = global;
+const dispatched = [];
+global.postMessage = msg => dispatched.push(msg);
+
+const ammoFactory = require(path.resolve(__dirname, "../dist/ammo.js"));
+
+// Register babel only for our src (never for dist/ammo.js or node_modules).
+require("@babel/register")({
+    ignore: [/node_modules/, /dist[\\/]ammo\.js$/],
+});
+
+const world = require("../src/physics/worker/world").default;
+const { addCompound, addSphere, setLinearVelocity } = require("../src/physics/worker/elements");
+const { PHYSICS_EVENTS } = require("../src/physics/messages");
+const { COLLIDER_TYPES } = require("../src/physics/constants");
+
+const IDENTITY_Q = { x: 0, y: 0, z: 0, w: 1 };
+const DT = 1 / 60;
+const STEPS = 150;
+
+const readPosition = uuid => {
+    const el = world.getElement(uuid);
+    const tr = new global.Ammo.btTransform();
+    el.body.getMotionState().getWorldTransform(tr);
+    const o = tr.getOrigin();
+    const pos = { x: o.x(), y: o.y(), z: o.z() };
+    global.Ammo.destroy(tr);
+    return pos;
+};
+
+const wallCollisions = () =>
+    dispatched.filter(
+        m =>
+            m.event === PHYSICS_EVENTS.DISPATCH &&
+            m.eventName === PHYSICS_EVENTS.ELEMENT.COLLISION &&
+            m.uuid === "wall",
+    ).length;
+
+// Reset the physics world between scenarios (fresh dynamics world + captured msgs).
+const resetWorld = () => {
+    dispatched.length = 0;
+    world.elements = {};
+    world.initialised = false;
+    world.init({ gravity: { x: 0, y: -30, z: 0 }, fixedTimeStep: 1 / 120, maxSubSteps: 5 });
+};
+
+// Floor (10 x 1 x 10) centered at origin, top at y = 0.5. Optional wall child
+// (1 x 4 x 10) resting on the floor at local +x. `floorQuat` bakes in a rotation
+// of the whole compound (to test that the child collider rotates with the root).
+const buildFloor = ({ floorQuat = IDENTITY_Q, withWall = true }) => {
+    const shapes = [
+        {
+            childUuid: "floor",
+            colliderType: COLLIDER_TYPES.BOX,
+            width: 10,
+            height: 1,
+            length: 10,
+            localPosition: { x: 0, y: 0, z: 0 },
+            localQuaternion: IDENTITY_Q,
+        },
+    ];
+    if (withWall) {
+        shapes.push({
+            childUuid: "wall",
+            colliderType: COLLIDER_TYPES.BOX,
+            width: 1,
+            height: 4,
+            length: 10,
+            localPosition: { x: 4, y: 2.5, z: 0 },
+            localQuaternion: IDENTITY_Q,
+        });
+    }
+    addCompound({
+        uuid: "floor",
+        position: { x: 0, y: 0, z: 0 },
+        quaternion: floorQuat,
+        mass: 0,
+        kinematic: true,
+        friction: 1,
+        shapes,
+    });
+};
+
+const addRollingSphere = (start, velocity) => {
+    addSphere({
+        uuid: "sphere",
+        radius: 0.5,
+        position: start,
+        quaternion: IDENTITY_Q,
+        mass: 1,
+        friction: 0.4,
+    });
+    setLinearVelocity({ uuid: "sphere", velocity });
+};
+
+const run = () => {
+    for (let i = 0; i < STEPS; i++) {
+        world.stepSimulation(DT);
+        world.calculateCollisions();
+    }
+    return readPosition("sphere");
+};
+
+const results = [];
+const check = (name, pass, detail) => {
+    results.push({ name, pass });
+    console.log(`${pass ? "PASS" : "FAIL"}  ${name}  — ${detail}`);
+};
+
+ammoFactory().then(A => {
+    global.Ammo = A;
+
+    // ── Scenario 1: wall child blocks the sphere ────────────────────────────
+    resetWorld();
+    buildFloor({ withWall: true });
+    addRollingSphere({ x: 0, y: 1.1, z: 0 }, { x: 12, y: 0, z: 0 });
+    let pos = run();
+    // Wall inner face at x = 3.5, sphere radius 0.5 → blocked near x = 3.0.
+    check(
+        "wall child stops sphere",
+        pos.x < 3.5 && wallCollisions() > 0,
+        `sphere.x=${pos.x.toFixed(2)} (expect <3.5), wallCollisions=${wallCollisions()}`,
+    );
+
+    // ── Scenario 2: rotate compound 90° about Y → wall now blocks along -z ───
+    resetWorld();
+    buildFloor({ withWall: true, floorQuat: { x: 0, y: Math.SQRT1_2, z: 0, w: Math.SQRT1_2 } });
+    addRollingSphere({ x: 0, y: 1.1, z: 0 }, { x: 0, y: 0, z: -12 });
+    pos = run();
+    // Wall now centered at world z = -4, inner face z = -3.5 → blocked near z = -3.0.
+    check(
+        "rotated compound carries wall collider",
+        pos.z > -3.5 && wallCollisions() > 0,
+        `sphere.z=${pos.z.toFixed(2)} (expect >-3.5), wallCollisions=${wallCollisions()}`,
+    );
+
+    // ── Control: no wall → sphere passes straight through the wall's location ─
+    resetWorld();
+    buildFloor({ withWall: false });
+    addRollingSphere({ x: 0, y: 1.1, z: 0 }, { x: 12, y: 0, z: 0 });
+    pos = run();
+    check(
+        "control (no wall) lets sphere pass",
+        pos.x > 3.5 && wallCollisions() === 0,
+        `sphere.x=${pos.x.toFixed(2)} (expect >3.5), wallCollisions=${wallCollisions()}`,
+    );
+
+    const failed = results.filter(r => !r.pass);
+    console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+    process.exit(failed.length ? 1 : 0);
+});

--- a/src/core/Importer.js
+++ b/src/core/Importer.js
@@ -46,6 +46,7 @@ import { Object3D } from "three";
 import Universe from "./universe";
 import Images from "../images/Images";
 import Scene from "./Scene";
+import Physics from "../physics";
 
 // class responsible for importing level data from a file
 export class Importer {
@@ -190,9 +191,36 @@ export class Importer {
             }
         }
 
-        // enable physics if options were configured
+        // Record physics intent, but defer body creation. The scene hierarchy
+        // isn't wired up yet at this point, so a parent + its rigidly-attached
+        // children can't be resolved into a single (compound) body until after
+        // the parenting passes below. Importer.realizePhysics() does that.
         if (elementData.physics?.options) {
-            element.enablePhysics(elementData.physics.options);
+            element.enablePhysics({ ...elementData.physics.options, deferPhysics: true });
+        }
+    }
+
+    // True if any ancestor of `element` already owns physics — meaning `element`
+    // is a welded child that belongs in an ancestor's compound body, not a root.
+    static hasPhysicsEnabledAncestor(element) {
+        let current = element.getParent && element.getParent();
+        while (current) {
+            if (current.isPhysicsEnabled && current.isPhysicsEnabled()) return true;
+            current = current.getParent ? current.getParent() : null;
+        }
+        return false;
+    }
+
+    // Build physics bodies now that the full hierarchy exists. Each physics
+    // subtree root (physics-enabled, no physics ancestor) is realized once;
+    // realizeSubtree folds its welded descendants into one compound body.
+    static realizePhysics(elements) {
+        for (const elementData of elements) {
+            if (!elementData.physics?.options) continue;
+            const element = Universe.getByUUID(elementData.uuid);
+            if (!element || !element.isPhysicsEnabled()) continue;
+            if (Importer.hasPhysicsEnabledAncestor(element)) continue;
+            Physics.realizeSubtree(element);
         }
     }
 
@@ -626,6 +654,10 @@ export class Importer {
                 }
             }
         }
+
+        // Hierarchy is fully wired up — now realize deferred physics bodies so a
+        // parent and its rigidly-attached children collide as one compound body.
+        Importer.realizePhysics(elements);
 
         lights.forEach(data => {
             try {

--- a/src/entities/Element.js
+++ b/src/entities/Element.js
@@ -453,6 +453,17 @@ export default class Element extends Entity {
         return !!this._physicsEnabled;
     }
 
+    // Reparenting changes which compound body a collider belongs to (a child
+    // welded to a kinematic floor vs. standing on its own). Reconcile physics
+    // after the scene-graph move so the departed/arrived collider is rebuilt
+    // rather than left stale in its former parent's compound.
+    reparent(newParent) {
+        const oldParent = this.getParent();
+        const result = super.reparent(newParent);
+        Physics.rebuildAfterReparent(this, oldParent);
+        return result;
+    }
+
     getAngularVelocity() {
         return this.angularVelocity || DEFAULT_ANGULAR_VELOCITY;
     }

--- a/src/entities/Element.js
+++ b/src/entities/Element.js
@@ -435,12 +435,22 @@ export default class Element extends Entity {
     }
 
     enablePhysics(options = {}) {
-        this.setPhysicsOptions(options);
+        const { deferPhysics = false, ...physicsOptions } = options;
+        this.setPhysicsOptions(physicsOptions);
         this._physicsEnabled = true;
 
-        if (Config.physics().enabled) {
-            Physics.add(this, options);
+        // During import (deferPhysics) the scene hierarchy isn't wired up yet, so
+        // we only record the intent here. Physics.realizeSubtree then builds one
+        // body per physics subtree — a compound of a parent plus its rigidly
+        // attached (scene-graph child) colliders — once parenting is complete.
+        // Direct runtime calls keep creating the body immediately.
+        if (!deferPhysics && Config.physics().enabled) {
+            Physics.add(this, physicsOptions);
         }
+    }
+
+    isPhysicsEnabled() {
+        return !!this._physicsEnabled;
     }
 
     getAngularVelocity() {

--- a/src/physics/__tests__/realizeSubtree.test.js
+++ b/src/physics/__tests__/realizeSubtree.test.js
@@ -1,4 +1,4 @@
-import { Object3D } from "three";
+import { Object3D, Mesh, BoxGeometry } from "three";
 import { PHYSICS_EVENTS } from "../messages";
 import { COLLIDER_TYPES } from "../constants";
 
@@ -129,6 +129,40 @@ describe("Physics.realizeSubtree", () => {
         expect(near(wall.localPosition.x, 4, 1e-4)).toBe(true);
         expect(near(wall.localPosition.y, 0, 1e-4)).toBe(true);
         expect(near(wall.localPosition.z, 0, 1e-4)).toBe(true);
+    });
+
+    it("sizes a rotated child by its true extents, not the inflated world AABB", () => {
+        // A thin upright wall (1 x 4 x 0.2) rotated 45° about Y and parented to an
+        // unrotated floor. Its world-axis-aligned AABB footprint is inflated to
+        // ~0.85 x 0.85; the collider must instead keep the true 1 x 0.2 footprint.
+        const floorBody = new Mesh(new BoxGeometry(10, 1, 10));
+        const wallBody = new Mesh(new BoxGeometry(1, 4, 0.2));
+        wallBody.position.set(0, 2.5, 3);
+        wallBody.rotation.set(0, Math.PI / 4, 0); // 45° about Y
+        floorBody.add(wallBody);
+        floorBody.updateMatrixWorld(true);
+
+        const wall = makeElement("wall", { colliderType: COLLIDER_TYPES.BOX }, wallBody);
+        const floor = makeElement("floor", { colliderType: COLLIDER_TYPES.BOX }, floorBody, [wall]);
+
+        Physics.realizeSubtree(floor);
+
+        const msg = Physics.worker.postMessage.mock.calls[0][0];
+        const wallShape = msg.shapes.find(s => s.childUuid === "wall");
+        // True extents preserved (not the ~0.85 inflated AABB).
+        expect(near(wallShape.width, 1, 1e-3)).toBe(true);
+        expect(near(wallShape.height, 4, 1e-3)).toBe(true);
+        expect(near(wallShape.length, 0.2, 1e-3)).toBe(true);
+        // Centered at the wall's world position, in the (unrotated) root frame.
+        expect(near(wallShape.localPosition.x, 0, 1e-3)).toBe(true);
+        expect(near(wallShape.localPosition.y, 2.5, 1e-3)).toBe(true);
+        expect(near(wallShape.localPosition.z, 3, 1e-3)).toBe(true);
+
+        // The floor shape must NOT swallow the wall child's geometry.
+        const floorShape = msg.shapes.find(s => s.childUuid === "floor");
+        expect(near(floorShape.width, 10, 1e-3)).toBe(true);
+        expect(near(floorShape.height, 1, 1e-3)).toBe(true);
+        expect(near(floorShape.length, 10, 1e-3)).toBe(true);
     });
 
     it("falls back to a single body when the root has no physics children", () => {

--- a/src/physics/__tests__/realizeSubtree.test.js
+++ b/src/physics/__tests__/realizeSubtree.test.js
@@ -1,0 +1,145 @@
+import { Object3D } from "three";
+import { PHYSICS_EVENTS } from "../messages";
+import { COLLIDER_TYPES } from "../constants";
+
+// index.js pulls in the bundler-only `worker:./worker` module and Config; stub
+// both so the Physics singleton is importable and "physics enabled" under jest.
+jest.mock("worker:./worker", () => ({ __esModule: true, default: class {} }), { virtual: true });
+jest.mock("../../core/config", () => ({
+    __esModule: true,
+    default: { physics: () => ({ enabled: true }) },
+}));
+// Keep utils real except the collider description, which would otherwise need
+// real geometry — we drive sizes via explicit collider* options instead.
+jest.mock("../utils", () => {
+    const actual = jest.requireActual("../utils");
+    return {
+        __esModule: true,
+        ...actual,
+        mapColliderTypeToDescription: () => () => ({
+            width: 1,
+            height: 1,
+            length: 1,
+            radius: 0.5,
+        }),
+    };
+});
+
+import Physics from "../index";
+
+// Fake element exposing just the surface realizeSubtree/buildCompoundShape use.
+const makeElement = (id, options, body, children = []) => ({
+    children,
+    isPhysicsEnabled: () => true,
+    uuid: () => id,
+    getPhysicsOptions: key => (key ? options[key] : options),
+    getBody: () => body,
+});
+
+const near = (actual, expected, eps = 1e-6) => Math.abs(actual - expected) < eps;
+
+beforeEach(() => {
+    Physics.elements = [];
+    Physics.worker = { postMessage: jest.fn() };
+});
+
+describe("Physics.realizeSubtree", () => {
+    it("emits ADD.COMPOUND with children expressed in the root's local frame", () => {
+        // Root body at world (1,0,2); child body parented at local (4,2.5,0).
+        const rootBody = new Object3D();
+        rootBody.position.set(1, 0, 2);
+        const childBody = new Object3D();
+        childBody.position.set(4, 2.5, 0);
+        rootBody.add(childBody);
+        rootBody.updateMatrixWorld(true);
+
+        const child = makeElement(
+            "wall",
+            {
+                colliderType: COLLIDER_TYPES.BOX,
+                colliderWidth: 1,
+                colliderHeight: 4,
+                colliderLength: 10,
+            },
+            childBody,
+        );
+        const root = makeElement(
+            "floor",
+            {
+                colliderType: COLLIDER_TYPES.BOX,
+                colliderWidth: 10,
+                colliderHeight: 1,
+                colliderLength: 10,
+                mass: 0,
+                kinematic: true,
+            },
+            rootBody,
+            [child],
+        );
+
+        Physics.realizeSubtree(root);
+
+        expect(Physics.worker.postMessage).toHaveBeenCalledTimes(1);
+        const msg = Physics.worker.postMessage.mock.calls[0][0];
+        expect(msg.event).toBe(PHYSICS_EVENTS.ADD.COMPOUND);
+        expect(msg.uuid).toBe("floor");
+        expect(msg.kinematic).toBe(true);
+
+        // Compound body sits at the root's world position.
+        expect(near(msg.position.x, 1) && near(msg.position.z, 2)).toBe(true);
+
+        // shapes[0] is the root at local identity; shapes[1] is the child at its
+        // parent-relative offset (4, 2.5, 0), NOT its world position (5, 2.5, 2).
+        expect(msg.shapes).toHaveLength(2);
+        expect(msg.shapes[0].childUuid).toBe("floor");
+        expect(msg.shapes[0].localPosition).toEqual({ x: 0, y: 0, z: 0 });
+
+        const wall = msg.shapes[1];
+        expect(wall.childUuid).toBe("wall");
+        expect(near(wall.localPosition.x, 4)).toBe(true);
+        expect(near(wall.localPosition.y, 2.5)).toBe(true);
+        expect(near(wall.localPosition.z, 0)).toBe(true);
+        // explicit collider* overrides win over the (mocked) description size
+        expect(wall.width).toBe(1);
+        expect(wall.height).toBe(4);
+        expect(wall.length).toBe(10);
+    });
+
+    it("keeps a child's offset in the root frame when the root is rotated", () => {
+        // Root rotated 90° about Y at the origin; child at local +x (4,0,0).
+        const rootBody = new Object3D();
+        rootBody.rotation.set(0, Math.PI / 2, 0);
+        const childBody = new Object3D();
+        childBody.position.set(4, 0, 0);
+        rootBody.add(childBody);
+        rootBody.updateMatrixWorld(true);
+
+        // Sanity: the child's WORLD position is rotated to roughly (0,0,-4)...
+        const worldChild = childBody.getWorldPosition(new Object3D().position);
+        expect(near(worldChild.z, -4, 1e-4)).toBe(true);
+
+        const child = makeElement("wall", { colliderType: COLLIDER_TYPES.BOX }, childBody);
+        const root = makeElement("floor", { colliderType: COLLIDER_TYPES.BOX }, rootBody, [child]);
+
+        Physics.realizeSubtree(root);
+
+        const msg = Physics.worker.postMessage.mock.calls[0][0];
+        // ...but expressed in the root's local frame it is back to (4,0,0).
+        const wall = msg.shapes[1];
+        expect(near(wall.localPosition.x, 4, 1e-4)).toBe(true);
+        expect(near(wall.localPosition.y, 0, 1e-4)).toBe(true);
+        expect(near(wall.localPosition.z, 0, 1e-4)).toBe(true);
+    });
+
+    it("falls back to a single body when the root has no physics children", () => {
+        const addSpy = jest.spyOn(Physics, "add").mockImplementation(() => {});
+        const rootBody = new Object3D();
+        const root = makeElement("lonely", { colliderType: COLLIDER_TYPES.BOX }, rootBody, []);
+
+        Physics.realizeSubtree(root);
+
+        expect(addSpy).toHaveBeenCalledTimes(1);
+        expect(Physics.worker.postMessage).not.toHaveBeenCalled();
+        addSpy.mockRestore();
+    });
+});

--- a/src/physics/__tests__/rebuildReparent.test.js
+++ b/src/physics/__tests__/rebuildReparent.test.js
@@ -1,0 +1,143 @@
+import { Object3D } from "three";
+import { PHYSICS_EVENTS } from "../messages";
+import { COLLIDER_TYPES } from "../constants";
+
+// Same stubs as realizeSubtree.test.js: index.js pulls in the bundler-only
+// worker module and Config; utils' collider description needs real geometry.
+jest.mock("worker:./worker", () => ({ __esModule: true, default: class {} }), { virtual: true });
+jest.mock("../../core/config", () => ({
+    __esModule: true,
+    default: { physics: () => ({ enabled: true }) },
+}));
+jest.mock("../utils", () => {
+    const actual = jest.requireActual("../utils");
+    return {
+        __esModule: true,
+        ...actual,
+        mapColliderTypeToDescription: () => () => ({ width: 1, height: 1, length: 1, radius: 0.5 }),
+    };
+});
+
+import Physics from "../index";
+
+const BOX = { colliderType: COLLIDER_TYPES.BOX };
+
+// Fake element with a mutable parent link + children so we can simulate reparents.
+const makeEl = (id, physicsEnabled, options, body) => {
+    const el = {
+        children: [],
+        _parent: null,
+        isPhysicsEnabled: () => physicsEnabled,
+        uuid: () => id,
+        getPhysicsOptions: key => (key ? options[key] : options),
+        getBody: () => body,
+        getParent: () => el._parent,
+    };
+    return el;
+};
+const link = (parent, child) => {
+    parent.children.push(child);
+    child._parent = parent;
+    parent.getBody().add(child.getBody());
+    parent.getBody().updateMatrixWorld(true);
+};
+const unlink = (parent, child, newBodyParent) => {
+    parent.children = parent.children.filter(c => c !== child);
+    child._parent = null;
+    newBodyParent.add(child.getBody()); // preserves nothing fancy; just keeps a valid world matrix
+    newBodyParent.updateMatrixWorld(true);
+};
+
+// Convenience: pull the events emitted to the worker since the last reset.
+const emitted = () => Physics.worker.postMessage.mock.calls.map(c => c[0]);
+const eventsFor = uuid => emitted().filter(m => m.uuid === uuid);
+
+beforeEach(() => {
+    Physics.elements = [];
+    Physics.worker = { postMessage: jest.fn() };
+});
+
+describe("Physics.rebuildAfterReparent", () => {
+    it("splits a compound when a child leaves to the scene root", () => {
+        const scene = new Object3D();
+        const floorBody = new Object3D();
+        scene.add(floorBody);
+        const wallBody = new Object3D();
+        wallBody.position.set(4, 2.5, 0);
+
+        const floor = makeEl("floor", true, BOX, floorBody);
+        const wall = makeEl("wall", true, BOX, wallBody);
+        link(floor, wall);
+
+        Physics.realizeSubtree(floor);
+        expect(Physics.elements).toEqual(["floor"]);
+        expect(eventsFor("floor")[0].event).toBe(PHYSICS_EVENTS.ADD.COMPOUND);
+
+        // Wall leaves the floor for the scene root.
+        Physics.worker.postMessage.mockClear();
+        unlink(floor, wall, scene);
+        Physics.rebuildAfterReparent(wall, floor);
+
+        const floorEvents = eventsFor("floor").map(m => m.event);
+        // Old compound torn down, floor rebuilt as a lone box (no physics children).
+        expect(floorEvents).toContain(PHYSICS_EVENTS.ELEMENT.DISPOSE);
+        expect(floorEvents).toContain(PHYSICS_EVENTS.ADD.BOX);
+        // Wall becomes its own body.
+        expect(eventsFor("wall").map(m => m.event)).toContain(PHYSICS_EVENTS.ADD.BOX);
+        expect(Physics.elements.sort()).toEqual(["floor", "wall"]);
+    });
+
+    it("moves a child's collider from one compound root to another", () => {
+        const scene = new Object3D();
+        const floorABody = new Object3D();
+        floorABody.position.set(-10, 0, 0);
+        const floorBBody = new Object3D();
+        floorBBody.position.set(10, 0, 0);
+        scene.add(floorABody, floorBBody);
+        const wallBody = new Object3D();
+        wallBody.position.set(1, 2.5, 0);
+
+        const floorA = makeEl("floorA", true, BOX, floorABody);
+        const floorB = makeEl("floorB", true, BOX, floorBBody);
+        const wall = makeEl("wall", true, BOX, wallBody);
+        link(floorA, wall);
+
+        Physics.realizeSubtree(floorA); // compound floorA + wall
+        Physics.realizeSubtree(floorB); // lone floorB box
+        expect(Physics.elements.sort()).toEqual(["floorA", "floorB"]);
+
+        // Wall moves from floorA to floorB.
+        Physics.worker.postMessage.mockClear();
+        unlink(floorA, wall, scene);
+        link(floorB, wall);
+        Physics.rebuildAfterReparent(wall, floorA);
+
+        // Both roots torn down and rebuilt: A loses the wall, B gains it.
+        expect(eventsFor("floorA").map(m => m.event)).toEqual(
+            expect.arrayContaining([PHYSICS_EVENTS.ELEMENT.DISPOSE, PHYSICS_EVENTS.ADD.BOX]),
+        );
+        expect(eventsFor("floorB").map(m => m.event)).toEqual(
+            expect.arrayContaining([PHYSICS_EVENTS.ELEMENT.DISPOSE, PHYSICS_EVENTS.ADD.COMPOUND]),
+        );
+        // floorB's rebuilt compound now contains the wall.
+        const floorBCompound = eventsFor("floorB").find(
+            m => m.event === PHYSICS_EVENTS.ADD.COMPOUND,
+        );
+        expect(floorBCompound.shapes.map(s => s.childUuid).sort()).toEqual(["floorB", "wall"]);
+        expect(Physics.elements.sort()).toEqual(["floorA", "floorB"]);
+    });
+
+    it("is a no-op before physics is realized (e.g. during import)", () => {
+        const floorBody = new Object3D();
+        const wallBody = new Object3D();
+        const floor = makeEl("floor", true, BOX, floorBody);
+        const wall = makeEl("wall", true, BOX, wallBody);
+        link(floor, wall);
+
+        // Nothing realized yet.
+        Physics.rebuildAfterReparent(wall, floor);
+
+        expect(Physics.worker.postMessage).not.toHaveBeenCalled();
+        expect(Physics.elements).toEqual([]);
+    });
+});

--- a/src/physics/constants.js
+++ b/src/physics/constants.js
@@ -6,6 +6,9 @@ export const TYPES = {
     VEHICLE: "VEHICLE",
     MESH: "MESH",
     PLAYER: "PLAYER",
+    // A single rigid body whose shape is a btCompoundShape made of a parent
+    // element's collider plus its rigidly-attached (scene-graph child) colliders.
+    COMPOUND: "COMPOUND",
 };
 
 export const COLLIDER_TYPES = {

--- a/src/physics/index.js
+++ b/src/physics/index.js
@@ -351,6 +351,104 @@ export class Physics extends EventDispatcher {
         });
     }
 
+    // Walk from `element` up its parent chain (inclusive) and return the topmost
+    // physics-enabled ancestor — the root whose compound body owns element's
+    // collider — or null if element is under no physics umbrella.
+    topmostPhysicsRoot(element) {
+        let root = null;
+        let current = element;
+        while (current) {
+            if (current.isPhysicsEnabled && current.isPhysicsEnabled()) root = current;
+            current = current.getParent ? current.getParent() : null;
+        }
+        return root;
+    }
+
+    // Physics roots (topmost-physics nodes) located within `element`'s subtree
+    // (inclusive) — used when a moved subtree ends up under no physics parent and
+    // each such node must become its own body again.
+    collectRootsInSubtree(element) {
+        const roots = [];
+        const visit = el => {
+            if (
+                el.isPhysicsEnabled &&
+                el.isPhysicsEnabled() &&
+                this.topmostPhysicsRoot(el) === el
+            ) {
+                roots.push(el);
+            }
+            (el.children || []).forEach(visit);
+        };
+        visit(element);
+        return roots;
+    }
+
+    // Already-realized bodies whose element sits inside `element`'s subtree
+    // (inclusive) — independent roots that travel with a moved subtree and whose
+    // bodies are therefore stale after the move.
+    realizedRootsInSubtree(element) {
+        const found = [];
+        const visit = el => {
+            if (el.uuid && this.elements.includes(el.uuid())) found.push(el);
+            (el.children || []).forEach(visit);
+        };
+        visit(element);
+        return found;
+    }
+
+    // Tear down a realized body by uuid (its compound or single body) without
+    // needing the element instance — used when reconciling reparents.
+    disposeByUuid(uuid) {
+        if (!this.worker || !this.elements.includes(uuid)) return;
+        this.elements.splice(this.elements.indexOf(uuid), 1);
+        this.worker.postMessage({ event: PHYSICS_EVENTS.ELEMENT.DISPOSE, uuid });
+    }
+
+    // Reconcile compound bodies after `element` was reparented away from
+    // `oldParent`. A child leaving/joining a physics parent changes which
+    // compound its collider belongs to, so we tear down the stale bodies on both
+    // sides of the move and rebuild the affected roots from the current hierarchy.
+    // No-op until physics is realized (e.g. during import), so import-time
+    // parenting is unaffected.
+    rebuildAfterReparent(element, oldParent) {
+        if (!Config.physics().enabled || !this.worker) return;
+        // Nothing realized yet (e.g. mid-import, before realizePhysics runs) —
+        // the final hierarchy will be realized in one pass, so stay out of it.
+        if (this.elements.length === 0) return;
+
+        const disposeUuids = new Set();
+        const realizeRoots = new Map();
+        const wantRealize = el => {
+            if (el && el.isPhysicsEnabled && el.isPhysicsEnabled()) {
+                realizeRoots.set(el.uuid(), el);
+            }
+        };
+
+        // Independent bodies that travelled inside the moved subtree are stale.
+        this.realizedRootsInSubtree(element).forEach(el => disposeUuids.add(el.uuid()));
+
+        // The root of the position element left loses element's colliders.
+        const oldRoot = oldParent ? this.topmostPhysicsRoot(oldParent) : null;
+        if (oldRoot) {
+            disposeUuids.add(oldRoot.uuid());
+            wantRealize(oldRoot);
+        }
+
+        // The root element landed under (inclusive of element) gains them; with no
+        // physics umbrella, each physics root in the moved subtree stands alone.
+        const newRoot = this.topmostPhysicsRoot(element);
+        if (newRoot) {
+            disposeUuids.add(newRoot.uuid());
+            wantRealize(newRoot);
+        } else {
+            this.collectRootsInSubtree(element).forEach(wantRealize);
+        }
+
+        // Dispose stale bodies first so realizeSubtree rebuilds from a clean slate.
+        disposeUuids.forEach(uuid => this.disposeByUuid(uuid));
+        realizeRoots.forEach(el => this.realizeSubtree(el));
+    }
+
     addVehicle(element, options) {
         if (Config.physics().enabled) {
             const uuid = element.uuid();

--- a/src/physics/index.js
+++ b/src/physics/index.js
@@ -1,4 +1,4 @@
-import { EventDispatcher, Vector3, Quaternion } from "three";
+import { EventDispatcher, Vector3, Quaternion, Box3, Matrix4 } from "three";
 import Universe from "../core/universe";
 import Config from "../core/config";
 import PhysicsWorker from "worker:./worker";
@@ -15,6 +15,7 @@ const { COLLIDER_TYPES } = PHYSICS_CONSTANTS;
 
 const {
     getBoxDescriptionForElement,
+    getWorldBoundingBoxSize,
     extractPositionAndQuaternion,
     mapColliderTypeToDescription,
     iterateGeometries,
@@ -263,22 +264,27 @@ export class Physics extends EventDispatcher {
     }
 
     // Describe one collider element in the compound root's local frame: its
-    // collider type, world-space size, and parent-relative position/rotation.
-    buildCompoundShape(element, rootWorldPos, invRootQuat) {
+    // collider type, size, and parent-relative position/rotation. `siblingBodies`
+    // are the bodies of the OTHER colliders in the compound (each becomes its own
+    // shape), so this element's geometry is measured without swallowing them.
+    buildCompoundShape(element, rootWorldPos, invRootQuat, siblingBodies) {
         const options = element.getPhysicsOptions() || {};
         const colliderType = options.colliderType || COLLIDER_TYPES.BOX;
-        const description = mapColliderTypeToDescription(colliderType)(element);
 
         const body = element.getBody();
-        const worldPos = body.getWorldPosition(new Vector3());
         const worldQuat = body.getWorldQuaternion(new Quaternion());
+        const excluded = new Set(siblingBodies.filter(b => b !== body));
 
-        // The compound body sits at (rootWorldPos, rootWorldQuat) with no scale,
-        // so a child's offset in that frame is its world displacement rotated
-        // back into the root's rotation. Size already comes from the world AABB,
-        // so we intentionally carry only rotation+translation here (no scale).
-        const localPos = worldPos.clone().sub(rootWorldPos).applyQuaternion(invRootQuat);
+        // Orientation of this collider relative to the compound root. The root
+        // body carries no scale, so children are placed with rotation +
+        // translation only.
         const localQuat = invRootQuat.clone().multiply(worldQuat);
+
+        const { worldCenter, size } = this.measureCollider(body, worldQuat, excluded);
+
+        // Position the shape at the collider's true world CENTER (a mesh's
+        // geometry can be offset from its element origin), in the root's frame.
+        const localPos = worldCenter.clone().sub(rootWorldPos).applyQuaternion(invRootQuat);
 
         const shape = {
             childUuid: element.uuid(),
@@ -287,19 +293,60 @@ export class Physics extends EventDispatcher {
             localQuaternion: { x: localQuat.x, y: localQuat.y, z: localQuat.z, w: localQuat.w },
         };
 
-        // World-space size, with explicit per-axis overrides (mirrors add()).
         if (colliderType === COLLIDER_TYPES.SPHERE) {
-            shape.radius =
-                options.colliderRadius != null ? options.colliderRadius : description.radius;
+            const radius = Math.max(size.width, size.height, size.length) / 2;
+            shape.radius = options.colliderRadius != null ? options.colliderRadius : radius;
         } else {
-            shape.width = options.colliderWidth != null ? options.colliderWidth : description.width;
-            shape.height =
-                options.colliderHeight != null ? options.colliderHeight : description.height;
-            shape.length =
-                options.colliderLength != null ? options.colliderLength : description.length;
+            shape.width = options.colliderWidth != null ? options.colliderWidth : size.width;
+            shape.height = options.colliderHeight != null ? options.colliderHeight : size.height;
+            shape.length = options.colliderLength != null ? options.colliderLength : size.length;
         }
 
         return shape;
+    }
+
+    // Measure a collider's own geometry: its world-space center and its *un-rotated*
+    // box size. Two things matter here:
+    //  - We skip `excluded` bodies (the compound's other collider elements, which
+    //    are THREE children of this body) so a parent shape doesn't swallow its
+    //    children's geometry.
+    //  - Size is measured after removing the element's world rotation, so a rotated
+    //    element (e.g. an upright wall) reports its real extents instead of an
+    //    inflated axis-aligned bound that localQuaternion would then rotate again.
+    // Falls back to the body origin / a unit box when there is no own geometry.
+    measureCollider(body, worldQuat, excluded) {
+        body.updateWorldMatrix(true, true);
+        const unrotate = new Matrix4().makeRotationFromQuaternion(worldQuat.clone().invert());
+        const worldBox = new Box3(); // for the center (axis-aligned, world)
+        const sizeBox = new Box3(); // for the size (rotation removed)
+        let found = false;
+
+        const visit = obj => {
+            if (obj !== body && excluded.has(obj)) return; // skip a child element's subtree
+            if (obj.geometry) {
+                if (!obj.geometry.boundingBox) obj.geometry.computeBoundingBox();
+                // World AABB (its center is the true world center of the box).
+                worldBox.union(obj.geometry.boundingBox.clone().applyMatrix4(obj.matrixWorld));
+                // Un-rotate and measure in ONE transform: applying matrixWorld
+                // first would already collapse the rotated box to an inflated
+                // axis-aligned bound. `unrotate * matrixWorld` has no net rotation,
+                // so the resulting AABB is the box's true (scaled) extent.
+                const combined = unrotate.clone().multiply(obj.matrixWorld);
+                sizeBox.union(obj.geometry.boundingBox.clone().applyMatrix4(combined));
+                found = true;
+            }
+            for (const child of obj.children) visit(child);
+        };
+        visit(body);
+
+        if (!found) {
+            const fallback = getWorldBoundingBoxSize(body) || { width: 1, height: 1, length: 1 };
+            return { worldCenter: body.getWorldPosition(new Vector3()), size: fallback };
+        }
+
+        const worldCenter = worldBox.getCenter(new Vector3());
+        const s = sizeBox.getSize(new Vector3());
+        return { worldCenter, size: { width: s.x, height: s.y, length: s.z } };
     }
 
     // Realize a physics subtree as a single rigid body. If `root` has no
@@ -326,8 +373,9 @@ export class Physics extends EventDispatcher {
 
         // shapes[0] is the root collider at local identity; the rest are children.
         const colliders = [root, ...descendants];
+        const colliderBodies = colliders.map(c => c.getBody());
         const shapes = colliders.map(element =>
-            this.buildCompoundShape(element, rootWorldPos, invRootQuat),
+            this.buildCompoundShape(element, rootWorldPos, invRootQuat, colliderBodies),
         );
 
         const options = root.getPhysicsOptions() || {};

--- a/src/physics/index.js
+++ b/src/physics/index.js
@@ -1,4 +1,4 @@
-import { EventDispatcher } from "three";
+import { EventDispatcher, Vector3, Quaternion } from "three";
 import Universe from "../core/universe";
 import Config from "../core/config";
 import PhysicsWorker from "worker:./worker";
@@ -243,6 +243,112 @@ export class Physics extends EventDispatcher {
                 uuid,
             });
         }
+    }
+
+    // Collect every physics-enabled descendant of `root` (its rigidly-attached
+    // children), descending through non-physics elements too. These become child
+    // shapes of the root's compound body.
+    collectPhysicsSubtree(root) {
+        const collected = [];
+        const walk = element => {
+            (element.children || []).forEach(child => {
+                if (child.isPhysicsEnabled && child.isPhysicsEnabled()) {
+                    collected.push(child);
+                }
+                walk(child);
+            });
+        };
+        walk(root);
+        return collected;
+    }
+
+    // Describe one collider element in the compound root's local frame: its
+    // collider type, world-space size, and parent-relative position/rotation.
+    buildCompoundShape(element, rootWorldPos, invRootQuat) {
+        const options = element.getPhysicsOptions() || {};
+        const colliderType = options.colliderType || COLLIDER_TYPES.BOX;
+        const description = mapColliderTypeToDescription(colliderType)(element);
+
+        const body = element.getBody();
+        const worldPos = body.getWorldPosition(new Vector3());
+        const worldQuat = body.getWorldQuaternion(new Quaternion());
+
+        // The compound body sits at (rootWorldPos, rootWorldQuat) with no scale,
+        // so a child's offset in that frame is its world displacement rotated
+        // back into the root's rotation. Size already comes from the world AABB,
+        // so we intentionally carry only rotation+translation here (no scale).
+        const localPos = worldPos.clone().sub(rootWorldPos).applyQuaternion(invRootQuat);
+        const localQuat = invRootQuat.clone().multiply(worldQuat);
+
+        const shape = {
+            childUuid: element.uuid(),
+            colliderType,
+            localPosition: { x: localPos.x, y: localPos.y, z: localPos.z },
+            localQuaternion: { x: localQuat.x, y: localQuat.y, z: localQuat.z, w: localQuat.w },
+        };
+
+        // World-space size, with explicit per-axis overrides (mirrors add()).
+        if (colliderType === COLLIDER_TYPES.SPHERE) {
+            shape.radius =
+                options.colliderRadius != null ? options.colliderRadius : description.radius;
+        } else {
+            shape.width = options.colliderWidth != null ? options.colliderWidth : description.width;
+            shape.height =
+                options.colliderHeight != null ? options.colliderHeight : description.height;
+            shape.length =
+                options.colliderLength != null ? options.colliderLength : description.length;
+        }
+
+        return shape;
+    }
+
+    // Realize a physics subtree as a single rigid body. If `root` has no
+    // physics-enabled descendants it takes the normal single-body path; otherwise
+    // root + welded children become one btCompoundShape body so rotating the root
+    // (e.g. a kinematic platform) carries every child collider with it.
+    realizeSubtree(root) {
+        if (!Config.physics().enabled) return;
+        if (this.hasElement(root)) return;
+
+        const descendants = this.collectPhysicsSubtree(root);
+
+        if (descendants.length === 0) {
+            this.add(root, root.getPhysicsOptions());
+            return;
+        }
+
+        const rootBody = root.getBody();
+        rootBody.updateWorldMatrix(true, true);
+
+        const rootWorldPos = rootBody.getWorldPosition(new Vector3());
+        const rootWorldQuat = rootBody.getWorldQuaternion(new Quaternion());
+        const invRootQuat = rootWorldQuat.clone().invert();
+
+        // shapes[0] is the root collider at local identity; the rest are children.
+        const colliders = [root, ...descendants];
+        const shapes = colliders.map(element =>
+            this.buildCompoundShape(element, rootWorldPos, invRootQuat),
+        );
+
+        const options = root.getPhysicsOptions() || {};
+
+        this.storeElement(root, options);
+
+        this.worker.postMessage({
+            event: PHYSICS_EVENTS.ADD.COMPOUND,
+            uuid: root.uuid(),
+            position: { x: rootWorldPos.x, y: rootWorldPos.y, z: rootWorldPos.z },
+            quaternion: {
+                x: rootWorldQuat.x,
+                y: rootWorldQuat.y,
+                z: rootWorldQuat.z,
+                w: rootWorldQuat.w,
+            },
+            mass: options.mass != null ? options.mass : 0,
+            friction: options.friction,
+            kinematic: !!options.kinematic,
+            shapes,
+        });
     }
 
     addVehicle(element, options) {

--- a/src/physics/messages.js
+++ b/src/physics/messages.js
@@ -14,6 +14,7 @@ export const PHYSICS_EVENTS = {
         MODEL: "physics:add:model",
         PLAYER: "physics:add:player",
         SPHERE: "physics:add:sphere",
+        COMPOUND: "physics:add:compound",
     },
 
     ELEMENT: {

--- a/src/physics/worker/__tests__/collisionResolve.test.js
+++ b/src/physics/worker/__tests__/collisionResolve.test.js
@@ -1,0 +1,64 @@
+import { COLLIDER_TYPES } from "../../constants";
+
+// world.js reads `self.requestAnimationFrame` at module load (it runs in a
+// WebWorker at runtime). Provide a `self` before requiring it under node/jest.
+let resolveChildUuid;
+beforeAll(() => {
+    global.self = global;
+    resolveChildUuid = require("../world").resolveChildUuid;
+});
+
+// Ammo hands contact points to us as btVector3s (accessed via .x()/.y()/.z()).
+const vec = (x, y, z) => ({ x: () => x, y: () => y, z: () => z });
+
+const identityQ = { x: 0, y: 0, z: 0, w: 1 };
+const floorChild = {
+    uuid: "floor",
+    colliderType: COLLIDER_TYPES.BOX,
+    localPosition: { x: 0, y: 0, z: 0 },
+    localQuaternion: identityQ,
+    halfExtents: { x: 5, y: 0.5, z: 5 },
+    radius: 0.5,
+};
+const wallChild = {
+    uuid: "wall",
+    colliderType: COLLIDER_TYPES.BOX,
+    localPosition: { x: 4, y: 2.5, z: 0 },
+    localQuaternion: identityQ,
+    halfExtents: { x: 0.5, y: 2, z: 5 },
+    radius: 0.5,
+};
+const childMap = [floorChild, wallChild];
+
+describe("resolveChildUuid", () => {
+    it("returns the body's own uuid for a plain (non-compound) body", () => {
+        expect(resolveChildUuid({ uuid: "sphere" }, vec(0, 0, 0))).toBe("sphere");
+    });
+
+    it("resolves a contact against the wall face to the wall child", () => {
+        expect(resolveChildUuid({ uuid: "floor", childMap }, vec(3.5, 2.5, 0))).toBe("wall");
+    });
+
+    it("resolves a contact on the floor surface to the floor child", () => {
+        expect(resolveChildUuid({ uuid: "floor", childMap }, vec(0, 0.5, 0))).toBe("floor");
+    });
+
+    it("returns the only child's uuid without inspecting the point", () => {
+        expect(resolveChildUuid({ uuid: "floor", childMap: [wallChild] }, vec(0, 0, 0))).toBe(
+            "wall",
+        );
+    });
+
+    it("resolves a rotated child's contact using its local quaternion", () => {
+        // Wall rotated 90° about Y: its local +x half-extent now spans local ±z.
+        const rotatedWall = {
+            ...wallChild,
+            localPosition: { x: 0, y: 2.5, z: 0 },
+            localQuaternion: { x: 0, y: Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
+        };
+        const map = [floorChild, rotatedWall];
+        // A point 0.4 along local z is inside the rotated wall (half-extent 0.5
+        // on what is now the z axis) but far outside the floor's thin y slab.
+        expect(resolveChildUuid({ uuid: "floor", childMap: map }, vec(0, 2.5, 0.4))).toBe("wall");
+    });
+});

--- a/src/physics/worker/__tests__/compound.test.js
+++ b/src/physics/worker/__tests__/compound.test.js
@@ -1,0 +1,142 @@
+import { TYPES, COLLIDER_TYPES } from "../../constants";
+
+jest.mock("../world", () => ({
+    __esModule: true,
+    default: { addRigidBody: jest.fn(), addElement: jest.fn(), getElement: jest.fn() },
+}));
+jest.mock("../lib/dispatcher", () => ({
+    __esModule: true,
+    default: { sendBodyUpdate: jest.fn() },
+}));
+jest.mock("../lib/math", () => ({ applyMatrix4ToVector3: jest.fn() }));
+
+import world from "../world";
+import { addCompound } from "../elements";
+
+// Fake Ammo just rich enough for addCompound → createRigidBody. We only assert
+// on how our code drives it (addChildShape count, childMap contents), not on
+// real physics — the real-Ammo proof lives in scripts/verify-compound-colliders.js.
+const installAmmo = () => {
+    const addChildShape = jest.fn();
+    const compound = { addChildShape, calculateLocalInertia: jest.fn() };
+    const body = {
+        getCollisionFlags: () => 1,
+        setCollisionFlags: jest.fn(),
+        setActivationState: jest.fn(),
+        activate: jest.fn(),
+        setFriction: jest.fn(),
+    };
+    global.Ammo = {
+        btCompoundShape: function () {
+            return compound;
+        },
+        btBoxShape: function () {
+            return { calculateLocalInertia: jest.fn() };
+        },
+        btSphereShape: function () {
+            return { calculateLocalInertia: jest.fn() };
+        },
+        btTransform: function () {
+            return { setIdentity: jest.fn(), setOrigin: jest.fn(), setRotation: jest.fn() };
+        },
+        btVector3: function (x, y, z) {
+            return { x, y, z };
+        },
+        btQuaternion: function (x, y, z, w) {
+            return { x, y, z, w };
+        },
+        btDefaultMotionState: function () {
+            return {};
+        },
+        btRigidBodyConstructionInfo: function () {
+            return {};
+        },
+        btRigidBody: function () {
+            return body;
+        },
+        destroy: jest.fn(),
+    };
+    return { compound, body, addChildShape };
+};
+
+afterEach(() => {
+    delete global.Ammo;
+    jest.clearAllMocks();
+});
+
+const box = (childUuid, dims, localPosition) => ({
+    childUuid,
+    colliderType: COLLIDER_TYPES.BOX,
+    localPosition,
+    localQuaternion: { x: 0, y: 0, z: 0, w: 1 },
+    ...dims,
+});
+
+const floorWithWall = {
+    uuid: "floor",
+    position: { x: 1, y: 0, z: 2 },
+    quaternion: { x: 0, y: 0, z: 0, w: 1 },
+    mass: 0,
+    kinematic: true,
+    friction: 1,
+    shapes: [
+        box("floor", { width: 10, height: 1, length: 10 }, { x: 0, y: 0, z: 0 }),
+        box("wall", { width: 1, height: 4, length: 10 }, { x: 4, y: 2.5, z: 0 }),
+    ],
+};
+
+describe("addCompound", () => {
+    it("adds one child shape to the compound per collider", () => {
+        const { addChildShape } = installAmmo();
+
+        addCompound(floorWithWall);
+
+        expect(addChildShape).toHaveBeenCalledTimes(2);
+    });
+
+    it("registers a COMPOUND element with a childMap mapping shape index → child uuid", () => {
+        installAmmo();
+
+        addCompound(floorWithWall);
+
+        expect(world.addElement).toHaveBeenCalledTimes(1);
+        const entry = world.addElement.mock.calls[0][0];
+        expect(entry.uuid).toBe("floor");
+        expect(entry.type).toBe(TYPES.COMPOUND);
+        expect(entry.childMap).toHaveLength(2);
+        expect(entry.childMap[0].uuid).toBe("floor");
+        expect(entry.childMap[1].uuid).toBe("wall");
+    });
+
+    it("stores each child's local placement and half-extents for contact resolution", () => {
+        installAmmo();
+
+        addCompound(floorWithWall);
+
+        const { childMap } = world.addElement.mock.calls[0][0];
+        expect(childMap[1].localPosition).toEqual({ x: 4, y: 2.5, z: 0 });
+        // width 1, height 4, length 10 → half-extents 0.5, 2, 5
+        expect(childMap[1].halfExtents).toEqual({ x: 0.5, y: 2, z: 5 });
+    });
+
+    it("builds a sphere leaf and records its radius", () => {
+        installAmmo();
+
+        addCompound({
+            ...floorWithWall,
+            shapes: [
+                {
+                    childUuid: "ball",
+                    colliderType: COLLIDER_TYPES.SPHERE,
+                    radius: 1.5,
+                    localPosition: { x: 0, y: 0, z: 0 },
+                    localQuaternion: { x: 0, y: 0, z: 0, w: 1 },
+                },
+            ],
+        });
+
+        const { childMap } = world.addElement.mock.calls[0][0];
+        expect(childMap[0].colliderType).toBe(COLLIDER_TYPES.SPHERE);
+        expect(childMap[0].radius).toBe(1.5);
+    });
+});

--- a/src/physics/worker/elements.js
+++ b/src/physics/worker/elements.js
@@ -6,6 +6,7 @@ import { applyMatrix4ToVector3 } from "./lib/math";
 import {
     DEFAULT_RIGIDBODY_STATE,
     TYPES,
+    COLLIDER_TYPES,
     DEFAULT_SCALE,
     DISABLE_DEACTIVATION,
     CF_STATIC_OBJECT,
@@ -226,6 +227,86 @@ export const addSphere = data => {
     });
 
     world.addElement({ uuid, body, type: TYPES.SPHERE, state: DEFAULT_RIGIDBODY_STATE });
+};
+
+// Build the leaf Ammo shape for one collider of a compound body. Mirrors the
+// shape construction in addBox/addSphere so a compound child collides exactly
+// like the equivalent standalone element would.
+const createLeafShape = ({ colliderType, width = 1, height = 1, length = 1, radius = 0.5 }) => {
+    if (colliderType === COLLIDER_TYPES.SPHERE) {
+        return new Ammo.btSphereShape(radius);
+    }
+    return new Ammo.btBoxShape(new Ammo.btVector3(width * 0.5, height * 0.5, length * 0.5));
+};
+
+// Descriptor kept per child shape so calculateCollisions can resolve which
+// child of the compound a contact belongs to (see world.resolveChildUuid). We
+// store the child's local placement + half-extents/radius so a contact's local
+// point can be tested against each child region.
+const makeChildDescriptor = (shape, index) => ({
+    index,
+    uuid: shape.childUuid,
+    colliderType: shape.colliderType,
+    localPosition: shape.localPosition || { x: 0, y: 0, z: 0 },
+    localQuaternion: shape.localQuaternion || { x: 0, y: 0, z: 0, w: 1 },
+    halfExtents: {
+        x: (shape.width || 1) * 0.5,
+        y: (shape.height || 1) * 0.5,
+        z: (shape.length || 1) * 0.5,
+    },
+    radius: shape.radius || 0.5,
+});
+
+// Realize a parent element and its rigidly-attached children as ONE rigid body
+// backed by a btCompoundShape. shapes[0] is the parent (root) collider at local
+// identity; the rest are children at their parent-relative transforms. Rotating
+// the single body rotates every child collider for free — no per-frame sync.
+export const addCompound = data => {
+    const {
+        uuid,
+        position,
+        quaternion,
+        mass = 0,
+        friction = 2,
+        kinematic = false,
+        shapes = [],
+    } = data;
+
+    const compound = new Ammo.btCompoundShape();
+    const childMap = [];
+
+    shapes.forEach((shape, index) => {
+        const leaf = createLeafShape(shape);
+
+        const localTransform = new Ammo.btTransform();
+        localTransform.setIdentity();
+        const lp = shape.localPosition || { x: 0, y: 0, z: 0 };
+        const lq = shape.localQuaternion || { x: 0, y: 0, z: 0, w: 1 };
+        localTransform.setOrigin(new Ammo.btVector3(lp.x, lp.y, lp.z));
+        localTransform.setRotation(new Ammo.btQuaternion(lq.x, lq.y, lq.z, lq.w));
+
+        compound.addChildShape(localTransform, leaf);
+        Ammo.destroy(localTransform);
+
+        childMap.push(makeChildDescriptor(shape, index));
+    });
+
+    const body = createRigidBody(compound, {
+        uuid,
+        position,
+        quaternion,
+        mass,
+        friction,
+        kinematic,
+    });
+
+    world.addElement({
+        uuid,
+        body,
+        type: TYPES.COMPOUND,
+        state: DEFAULT_RIGIDBODY_STATE,
+        childMap,
+    });
 };
 
 export const setLinearVelocity = data => {

--- a/src/physics/worker/index.js
+++ b/src/physics/worker/index.js
@@ -4,6 +4,7 @@ import { addVehicle, resetVehicle, setVehiclePosition, setVehicleQuaternion } fr
 import {
     addBox,
     addModel,
+    addCompound,
     setLinearVelocity,
     applyImpuse,
     addSphere,
@@ -28,6 +29,9 @@ const handleLoadEvent = options => Ammo => {
                 break;
             case PHYSICS_EVENTS.ADD.SPHERE:
                 addSphere(data);
+                break;
+            case PHYSICS_EVENTS.ADD.COMPOUND:
+                addCompound(data);
                 break;
             case PHYSICS_EVENTS.ADD.VEHICLE:
                 addVehicle(data);

--- a/src/physics/worker/world.js
+++ b/src/physics/worker/world.js
@@ -1,4 +1,4 @@
-import { GRAVITY, TYPES } from "../constants";
+import { GRAVITY, TYPES, COLLIDER_TYPES } from "../constants";
 
 import { handleElementUpdate } from "./elements";
 import { handleVehicleUpdate } from "./vehicles";
@@ -35,6 +35,74 @@ class Clock {
         }
     }
 }
+// Rotate a plain vector by the inverse (conjugate, for a unit quaternion) of q.
+// Used to bring a body-local contact point into a compound child's own frame.
+const rotateByInverseQuaternion = (v, q) => {
+    const cx = -q.x;
+    const cy = -q.y;
+    const cz = -q.z;
+    const cw = q.w;
+    // t = 2 * cross(c.xyz, v)
+    const tx = 2 * (cy * v.z - cz * v.y);
+    const ty = 2 * (cz * v.x - cx * v.z);
+    const tz = 2 * (cx * v.y - cy * v.x);
+    // v' = v + cw * t + cross(c.xyz, t)
+    return {
+        x: v.x + cw * tx + (cy * tz - cz * ty),
+        y: v.y + cw * ty + (cz * tx - cx * tz),
+        z: v.z + cw * tz + (cx * ty - cy * tx),
+    };
+};
+
+// Signed distance from a body-local point to one compound child's region:
+// negative inside, ~0 on the surface, positive outside.
+const signedDistanceToChild = (localPoint, child) => {
+    const rel = {
+        x: localPoint.x - child.localPosition.x,
+        y: localPoint.y - child.localPosition.y,
+        z: localPoint.z - child.localPosition.z,
+    };
+    const d = rotateByInverseQuaternion(rel, child.localQuaternion);
+
+    if (child.colliderType === COLLIDER_TYPES.SPHERE) {
+        return Math.sqrt(d.x * d.x + d.y * d.y + d.z * d.z) - child.radius;
+    }
+
+    const qx = Math.abs(d.x) - child.halfExtents.x;
+    const qy = Math.abs(d.y) - child.halfExtents.y;
+    const qz = Math.abs(d.z) - child.halfExtents.z;
+    const ox = Math.max(qx, 0);
+    const oy = Math.max(qy, 0);
+    const oz = Math.max(qz, 0);
+    const outside = Math.sqrt(ox * ox + oy * oy + oz * oz);
+    const inside = Math.min(Math.max(qx, qy, qz), 0);
+    return outside + inside;
+};
+
+// Resolve which element uuid a contact belongs to. Plain bodies (no childMap)
+// resolve to their own uuid — a no-op that keeps existing behaviour. Compound
+// bodies pick the child whose region the body-local contact point falls in (or
+// is closest to), so per-child OnCollision/applyImpulse still fire. `localPoint`
+// is an Ammo btVector3 (accessed via .x()/.y()/.z()).
+export const resolveChildUuid = (element, localPoint) => {
+    if (!element) return undefined;
+    const { childMap, uuid } = element;
+    if (!childMap || childMap.length === 0) return uuid;
+    if (childMap.length === 1) return childMap[0].uuid;
+
+    const point = { x: localPoint.x(), y: localPoint.y(), z: localPoint.z() };
+    let best = childMap[0];
+    let bestDist = Infinity;
+    for (let k = 0; k < childMap.length; k++) {
+        const dist = signedDistanceToChild(point, childMap[k]);
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = childMap[k];
+        }
+    }
+    return best.uuid;
+};
+
 export class World {
     constructor() {
         this.elements = {};
@@ -138,6 +206,7 @@ export class World {
                     case TYPES.BOX:
                     case TYPES.SPHERE:
                     case TYPES.MESH:
+                    case TYPES.COMPOUND:
                         handleElementUpdate(element, dt);
                         break;
                     case TYPES.PLAYER:
@@ -175,7 +244,16 @@ export class World {
             // this iteration doesn't have uuids
             if (!rb0.uuid || !rb1.uuid) continue;
 
+            // For compound bodies these carry a childMap; for plain bodies the
+            // lookup returns an entry with no childMap and resolution is a no-op
+            // that yields the body's own uuid.
+            const element0 = this.getElement(rb0.uuid);
+            const element1 = this.getElement(rb1.uuid);
+
             let contacts = [];
+            // Elements that should receive this collision: the two body roots
+            // plus, for compounds, the specific child colliders actually hit.
+            const targets = new Set([rb0.uuid, rb1.uuid]);
 
             for (let j = 0; j < numContacts; j++) {
                 let contactPoint = contactManifold.getContactPoint(j);
@@ -190,17 +268,25 @@ export class World {
                 let localPos0 = contactPoint.get_m_localPointA();
                 let localPos1 = contactPoint.get_m_localPointB();
 
+                // Map the contact to the compound child it belongs to (or the
+                // body's own uuid for a plain body) so per-child collision
+                // scripting keeps working.
+                const uuid0 = resolveChildUuid(element0, localPos0);
+                const uuid1 = resolveChildUuid(element1, localPos1);
+                targets.add(uuid0);
+                targets.add(uuid1);
+
                 contacts.push({
                     distance,
                     elements: [
                         {
-                            uuid: rb0.uuid,
+                            uuid: uuid0,
                             velocity: { x: velocity0.x(), y: velocity0.y(), z: velocity0.z() },
                             worldPos: { x: worldPos0.x(), y: worldPos0.y(), z: worldPos0.z() },
                             localPos: { x: localPos0.x(), y: localPos0.y(), z: localPos0.z() },
                         },
                         {
-                            uuid: rb1.uuid,
+                            uuid: uuid1,
                             velocity: { x: velocity1.x(), y: velocity1.y(), z: velocity1.z() },
                             worldPos: { x: worldPos1.x(), y: worldPos1.y(), z: worldPos1.z() },
                             localPos: { x: localPos1.x(), y: localPos1.y(), z: localPos1.z() },
@@ -209,8 +295,9 @@ export class World {
                 });
             }
 
-            dispatcher.sendDispatchEvent(rb0.uuid, PHYSICS_EVENTS.ELEMENT.COLLISION, { contacts });
-            dispatcher.sendDispatchEvent(rb1.uuid, PHYSICS_EVENTS.ELEMENT.COLLISION, { contacts });
+            targets.forEach(uuid =>
+                dispatcher.sendDispatchEvent(uuid, PHYSICS_EVENTS.ELEMENT.COLLISION, { contacts }),
+            );
         }
     };
 


### PR DESCRIPTION
## Problem

When an element is parented to another (e.g. a wall added to a kinematic floor/platform), only the **parent** got a physics collider. The engine created one independent, world-space rigid body per element and never told a child's body about its parent's motion — so rotating/tilting a kinematic parent moved the child visually but left its collider frozen and mis-placed. A ball rolling on the platform passed straight through the wall.

## Approach

Represent a parent **plus its rigidly-attached (scene-graph child) colliders as a single Ammo `btCompoundShape` body** — the engine-native way to model one rigid body made of several shapes. Rotating the root now carries every child collider with it for free (no per-frame sync), and per-child collision identity is preserved.

## Changes

**Compound bodies (worker + engine)**
- `constants.js` / `messages.js` — new `TYPES.COMPOUND` and `ADD.COMPOUND` event.
- `worker/elements.js` — `addCompound()` builds a `btCompoundShape` (parent shape + child shapes at their local offsets) plus a `childMap`.
- `worker/index.js` / `worker/world.js` — route the new event, step compound bodies, and resolve each contact back to the specific child (`resolveChildUuid`) so per-child `OnCollision` / `applyImpulse` still fire.
- `physics/index.js` — `Physics.realizeSubtree()` gathers a subtree's physics elements and emits one compound (or the normal single-body path when there are no physics children).
- `entities/Element.js` / `core/Importer.js` — **defer** physics during import (`deferPhysics` + `isPhysicsEnabled`), then realize each root **after** the hierarchy is wired up.

**Rebuild on runtime reparent**
- `Element.reparent()` → `Physics.rebuildAfterReparent()`: when a child leaves / joins / moves at runtime, the affected compound bodies are torn down and rebuilt from the current hierarchy. No-ops during import and in the editor (physics disabled), so those paths are unaffected.

**Correct collider placement**
- `measureCollider()` sizes each shape from its **un-rotated** extents (so a wall rotated relative to the platform isn't inflated by a world-AABB and then rotated again), positions it at the true geometry **center** (handles geometry offset from the element origin), and measures only the element's **own** geometry (a parent shape no longer swallows its children).

## Tests

- New suites: `worker/__tests__/compound.test.js`, `worker/__tests__/collisionResolve.test.js`, `__tests__/realizeSubtree.test.js`, `__tests__/rebuildReparent.test.js`.
- Full suite: **528 passing**.
- `scripts/verify-compound-colliders.js` — a real-Ammo integration harness (loads the vendored `dist/ammo.js`, steps a real world) proving collision response end-to-end: wall child blocks the ball, a rotated compound carries the wall collider, and a reparent-out removes it (4/4).

## Notes / follow-ups

- Verified in mage-studio: a tilting-labyrinth platform with a wall child and a rolling ball now collides correctly at any orientation.
- Out of scope: independently-simulated (non-welded) physics children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)